### PR TITLE
Split node_exporter env vars

### DIFF
--- a/exporter/README.md
+++ b/exporter/README.md
@@ -4,7 +4,7 @@
 
 * Install latest node_exporter package from Crunchy Repository
 * Install latest postgres_exporter package from Crunchy Repository
-* Install latest crunchy-monitoring-extras-pg## package for your major version of PostgreSQL
+* Install latest crunchy-monitoring-pg##-extras package for your major version of PostgreSQL
 * Install latest crunchy-pg_bloat-check package if you need to monitor database bloat
 
 ## Service Setup (RHEL/CENTOS 7)

--- a/exporter/node/crunchy-node-exporter-service-el7.conf.example
+++ b/exporter/node/crunchy-node-exporter-service-el7.conf.example
@@ -8,6 +8,6 @@ PermissionsStartOnly=true
 User=ccp_monitoring
 EnvironmentFile=/etc/sysconfig/node_exporter
 ExecStart=
-ExecStart=/usr/bin/node_exporter ${OPTIONS}
+ExecStart=/usr/bin/node_exporter ${TEXTFILE_DIR} ${IGNORED_DEVICES}
 ExecReload=/usr/bin/kill -HUP $MAINPID
 Restart=always

--- a/exporter/node/sysconfig.node_exporter.example
+++ b/exporter/node/sysconfig.node_exporter.example
@@ -1,3 +1,7 @@
 # Copy this file to a pathname that matches the EnvironmentFile entry in the service file (Default: /etc/sysconfig/node_exporter)
+#
+# TEXFILE_DIR is the location that node_exporter will look for additional metric collection scripts to run
+# IGNORED_DEVICES is a regex string of devices to ignore
 
-OPTIONS="--collector.textfile.directory=/var/lib/ccp_monitoring/node_exporter --collector.diskstats.ignored-devices="^(ram|loop|fd)\\d+$ "
+TEXTFILE_DIR='--collector.textfile.directory=/var/lib/ccp_monitoring/node_exporter'
+IGNORED_DEVICES='--collector.diskstats.ignored-devices="^(ram|loop|fd)\\d+$ "'


### PR DESCRIPTION
Suddenly node_exporter started having the same env variable issues we had with postgres_exporter. Split them out and documented them better as well. 