### PR TITLE
Ignore exporter metrics. Non-package install instructions.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+1.4
+-- Fixed filesystem graphs in PostgreSQLDetails dashboard
+-- Cosmetic changes to PostgreSQLDetails dashboard
+-- Added instructions for importing dashboards via Grafana API
+
+
 1.3
 -- Fixed error in PG10 queries file. 
 -- Fixed disk usage alert for prometheus to work better when there are many jobs with similar mountpoints. Also fixed syntax error in warning alert.

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -2,7 +2,7 @@
 
 ## Installation (RHEL/CENTOS 7)
 
-RPMs are available to Crunchy customers through our access portal. The RPM will take care of all the steps below in the Installation section. From the Setup section onward, the instructions are relevant no matter the installation method.
+There are RPM packages available to [Crunchy Data](https://www.crunchydata.com) customers through the Crunchy Data [access portal](https://access.crunchydata.com/).  Installing these RPMs will take care of all of the steps described in this Installation section. If you install via the RPM, you can continue reading at the [Service Setup](#service-setup-rhelcentos-7) section.
 
 Packages available: node_exporter, postgres_exporter, pgmonitor-pg##-extras, pg_bloat_check 
 

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -1,17 +1,47 @@
 # Setting up exporters
 
-## Installation
+## Installation (RHEL/CENTOS 7)
 
-* Install latest node_exporter package from Crunchy Repository
-* Install latest postgres_exporter package from Crunchy Repository
-* Install latest pgmonitor-pg##-extras package for your major version of PostgreSQL
-* Install latest crunchy-pg_bloat-check package if you need to monitor database bloat
+RPMs are available to Crunchy customers through our access portal. The RPM will take care of all the steps below in the Installation section. From the Setup section onward, the instructions are relevant no matter the installation method.
+
+Packages available: node_exporter, postgres_exporter, pgmonitor-pg##-extras, pg_bloat_check 
+
+For non-package installations, the exporters & pg_bloat_check can be downloaded from their respective repositories. 
+ * https://github.com/prometheus/node_exporter/releases
+ * https://github.com/wrouesnel/postgres_exporter/releases
+ * https://github.com/keithf4/pg_bloat_check
+
+All executables are expected to be in /usr/bin. A base node_exporter systemd file is expected to be in place already. An example one can be found here https://github.com/lest/prometheus-rpm/tree/master/node_exporter
+
+The files contained in this repository are assumed to be installed in the following locations with the following names. A double hash is replaced by the two-digit major version of PostgreSQL you are running (ex: 95, 96, 10, etc).
+```
+Folder /var/lib/ccp_monitoring/node_exporter is used for custom monitor script output. It is assumed to be owned by ccp_monitoring user.
+
+- node/crunchy-node-exporter-service-el7.conf -> /etc/systemd/system/node_exporter.service.d/crunchy-node-exporter-service-el7.conf
+- node/sysconfig.node_exporter -> /etc/sysconfig/node_exporter
+- node/ccp_pg_isready##.sh -> /usr/bin/ccp_pg_isready##.sh
+
+- crontab##.txt -> /etc/postgres_exporter/##/crontab##.txt
+
+- postgres/crunchy_postgres_exporter@.service -> /usr/lib/systemd/system/crunchy_postgres_exporter@.service
+
+- postgres/sysconfig.postgres_exporter_pg## -> /etc/sysconfig/postgres_exporter_p##
+- /etc/sysconfig/postgres_exporter symlinked to /etc/sysconfig/postgres_exporter_p##
+
+- postgres/functions_pg##.sql -> /etc/postgres_exporter/##/functions_pg##.sql
+- postgres/queries_pg##.yml -> /etc/postgres_exporter/##/queries_pg##.yml 
+- postgres/queries_common.yml -> /etc/postgres_exporter/##/queries_common.yml
+- postgres/queries_per_db.yml -> /etc/postgres_exporter/##/queries_per_db.yml
+- postgres/queries_bloat.yml -> /etc/postgres_exporter/##/queries_bloat.yml
+- postgres/queries_pg_stat_statements.yml -> /etc/postgres_exporter/##/queries_pg_stat_statements.yml
+
+```
 
 ## Service Setup (RHEL/CENTOS 7)
 
 * If necessary, modify /etc/systemd/system/node_exporter.service.d/crunchy-node-exporter-service-el7.conf. See notes in file for more details.
 * If necessary, modify /etc/sysconfig/node_exporter. See notes in file for more details.
-* If necessary, modify /etc/sysconfig/postgres_exporter. See notes in file for more details.
+* If necessary, modify /etc/sysconfig/postgres_exporter. See notes in file for more details. Also note this is a symlink to avoid issues during PG major version upgrades.
 * Modify /etc/postgres_exporter/##/crontab##.txt to run relevant scripts and schedule the bloat check for off-peak hours. Add crontab entries manually to ccp_monitoring user (or user relevant for your environment).
 
 ## Database Setup
@@ -111,18 +141,31 @@ The service override file(s) must be placed in the relevant drop-in folder to ov
 After a daemon-reload, systemd should automatically find these files and the crunchy services should work as intended.
  
 
-## Setup (RHEL/CENTOS 6)
+## Installation & Setup (RHEL/CENTOS 6)
 
 The node_exporter and postgres_exporter services on RHEL6 require the "daemonize" package that is part of the EPEL repository. This can be turned on by running:
 
     sudo yum install epel-release
 
-All setup for the exporters is the same on RHEL6 as it was for 7 with the exception of the base service files. Whereas RHEL7 uses systemd, RHEL6 uses init.d. The RHEL6 packages will create the base service files for you
+All setup for the exporters is the same on RHEL6 as it was for 7 with the exception of the base service files. Whereas RHEL7 uses systemd, RHEL6 uses init.d. The Crunchy RHEL6 packages will create the base service files for you
 
     /etc/init.d/crunchy-node-exporter
     /etc/init.d/crunchy-postgres-exporter
 
 Note that these service files are managed by the package and any changes you make to them could be overwritten by future updates. If you need to customize the service files for RHEL6, it's recommended making a copy and editing/using those.
+
+Or if you are setting this up manually, the repository file locations and expected directories are:
+```
+node/crunchy-node-exporter-el6.service -> /etc/init.d/crunchy-postgres-exporter
+postgres/crunchy-postgres-exporter-el6.service -> /etc/init.d/crunchy-postgres-exporter
+
+/var/run/postgres_exporter/
+/var/log/postgres_exporter/ (owned by postgres_exporter service user)
+
+/var/run/node_exporter/
+/var/log/node_exporter/ (owned by node_exporter service user)
+
+```
 
 The same /etc/sysconfig files that are used in RHEL7 above are also used in RHEL6, so follow guidance above concerning them and the notes that are contained in the files themselves.
 

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -1,12 +1,24 @@
 # Setting up Prometheus
 
-## Installation
+## Installation (RHEL/CENTOS 7)
 
-* Install latest Prometheus package from Crunchy Repository
-* Install latest Alertmanager package from Crunchy Repository
-* Install latest pgmonitor-prometheus-extras package
-* Install latest pgmonitor-alertmanager-extras package
+RPMs are available to Crunchy customers through our access portal. The RPM will take care of all the steps below in the Installation section. From the Setup section onward, the instructions are relevant no matter the installation method.
 
+Packages available: prometheus2, alertmanager, pgmonitor-prometheus-extras, pgmonitor-alertmanager-extras
+
+For non-package installations, Prometheus & Alertmanager can be downloaded from the developer website (https://prometheus.io/download). The minimum expected versions are Prometheus is 2.0 and Alertmanager 0.12.0. The files contained in this repository are assumed to be installed in the following locations with the following names:
+```
+Prometheus data folder assumed to be /var/lib/ccp_monitoring/prometheus and owned by ccp_monitoring user. If not, edit sysconfig file appropriately.
+- crunchy-prometheus-service-el7.conf -> /etc/systemd/system/prometheus.service.d/crunchy-prometheus-service-el7.conf 
+- sysconfig.prometheus -> /etc/sysconfig/prometheus
+- crunchy-prometheus.yml -> /etc/prometheus/crunchy-prometheus.yml
+- auto.d/ProductionDB.yml.example -> /etc/prometheus/auto.d/ProductionDB.yml.example
+- crunchy-alert-rules.yml -> /etc/prometheus/crunchy-alert-rules.yml
+
+Alertmanager data folder assumed to be /var/lib/ccp_monitoring/alertmanager and owned by ccp_monitoring user. If not, edit sysconfig file appropriately.
+- crunchy-alertmanager-service-el7.conf -> /etc/systemd/system/alertmanager.service.d/crunchy-alertmanager-service-el7.conf
+- sysconfig.alertmanager -> /etc/sysconfig/alertmanager
+```
 ## Setup (RHEL/CENTOS 7)
 
 * If necessary, modify /etc/systemd/system/prometheus.service.d/crunchy-prometheus-service-el7.conf. See notes in example file for more details.

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -2,7 +2,7 @@
 
 ## Installation (RHEL/CENTOS 7)
 
-RPMs are available to Crunchy customers through our access portal. The RPM will take care of all the steps below in the Installation section. From the Setup section onward, the instructions are relevant no matter the installation method.
+There are RPM packages available to [Crunchy Data](https://www.crunchydata.com) customers through the Crunchy Data [access portal](https://access.crunchydata.com/).  Installing these RPMs will take care of all of the steps described in this Installation section. If you install via the RPM, you can continue reading at the [Setup](#setup-rhelcentos-7) section.
 
 Packages available: prometheus2, alertmanager, pgmonitor-prometheus-extras, pgmonitor-alertmanager-extras
 

--- a/prometheus/crunchy-prometheus.yml
+++ b/prometheus/crunchy-prometheus.yml
@@ -21,7 +21,12 @@ scrape_configs:
     - files:
       - /etc/prometheus/auto.d/*.yml
 
-        
+    # Do not store the metrics that come built into postgres_exporter
+    metric_relabel_configs:
+    - source_labels: [ __name__ ]
+      regex: '(pg_locks_count.*|pg_settings.*|pg_stat_activity.*|pg_stat_bgwriter.*|pg_stat_database.*)'
+          action: drop
+
 #### Uncomment below if using alertmanager ####        
 #
 #rule_files:


### PR DESCRIPTION
Added config option to prometheus so it stops storing the built-in metrics from postgres_exporter that we are not using.

Also updated the README's to include some instructions for non-package installs. Can work on splitting it out to different files once we start supporting other OS's besides RHEL/Centos.