### PR TITLE
Add metric and rule for max query runtime

### DIFF
--- a/exporter/postgres/queries_pg10.yml
+++ b/exporter/postgres/queries_pg10.yml
@@ -6,7 +6,7 @@ ccp_connection_stats:
         , idle
         , idle_in_txn
         , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where state = 'idle in transaction') as max_idle_in_txn_time
-        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from monitor.pg_stat_activity where backend_type = 'client backend' ) as max_query_time
+        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and state <> 'idle' ) as max_query_time
         , max_connections
         from (
                 select count(*) as total

--- a/exporter/postgres/queries_pg10.yml
+++ b/exporter/postgres/queries_pg10.yml
@@ -6,6 +6,7 @@ ccp_connection_stats:
         , idle
         , idle_in_txn
         , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where state = 'idle in transaction') as max_idle_in_txn_time
+        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from monitor.pg_stat_activity where backend_type = 'client backend' ) as max_query_time
         , max_connections
         from (
                 select count(*) as total
@@ -28,6 +29,9 @@ ccp_connection_stats:
     - max_idle_in_txn_time:
         usage: "GAUGE"
         description: "Length of time in seconds of the longest idle in transaction session"
+    - max_query_time:
+        usage: "GAUGE"
+        description: "Length of time in seconds of the longest running query"
     - max_connections:
         usage: "GAUGE"
         description: "Value of max_connections for the monitored database"

--- a/exporter/postgres/queries_pg92-96.yml
+++ b/exporter/postgres/queries_pg92-96.yml
@@ -6,6 +6,7 @@ ccp_connection_stats:
         , idle
         , idle_in_txn
         , (select coalesce(extract(epoch from (max(now() - query_start))),0) from monitor.pg_stat_activity() where state = 'idle in transaction') as max_idle_in_txn_time
+        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from monitor.pg_stat_activity() ) as max_query_time
         , max_connections
         from (
                 select count(*) as total
@@ -28,6 +29,9 @@ ccp_connection_stats:
     - max_idle_in_txn_time:
         usage: "GAUGE"
         description: "Length of time in seconds of the longest idle in transaction session"
+    - max_query_time:
+        usage: "GAUGE"
+        description: "Length of time in seconds of the longest running query"
     - max_connections:
         usage: "GAUGE"
         description: "Value of max_connections for the monitored database"

--- a/exporter/postgres/queries_pg92-96.yml
+++ b/exporter/postgres/queries_pg92-96.yml
@@ -6,7 +6,7 @@ ccp_connection_stats:
         , idle
         , idle_in_txn
         , (select coalesce(extract(epoch from (max(now() - query_start))),0) from monitor.pg_stat_activity() where state = 'idle in transaction') as max_idle_in_txn_time
-        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from monitor.pg_stat_activity() ) as max_query_time
+        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from monitor.pg_stat_activity() where state <> 'idle') as max_query_time
         , max_connections
         from (
                 select count(*) as total

--- a/prometheus/crunchy-alert-rules.yml
+++ b/prometheus/crunchy-alert-rules.yml
@@ -62,6 +62,26 @@ groups:
       description: '{{ $labels.job }} has at least one session idle in transaction for over 15 minutes.'
       summary: 'PGSQL Instance idle transactions'
 
+  - alert: PGQueryTime
+    expr: ccp_connection_stats_max_query_time > 43200
+    for: 60s
+    labels:
+      service: postgresql
+      severity: warning 
+    annotations:
+      description: '{{ $labels.job }} has at least one query running for over 12 hours.'
+      summary: 'PGSQL Max Query Runtime'
+
+  - alert: PGQueryTime
+    expr: ccp_connection_stats_max_query_time > 86400 
+    for: 60s
+    labels:
+      service: postgresql
+      severity: critical
+    annotations:
+      description: '{{ $labels.job }} has at least one query running for over 1 day.'
+      summary: 'PGSQL Max Query Runtime'
+
   - alert: PGConnPerc
     expr: 100 * (ccp_connection_stats_total / ccp_connection_stats_max_connections) > 90 
     for: 60s


### PR DESCRIPTION
Tested this on 9.5, which should cover 9.2-9.6
Did not test on PG10 yet which should be done before merging.