### PR TITLE
Add if not exist check for ccp_monitoring role

### DIFF
--- a/exporter/postgres/setup_pg10.sql
+++ b/exporter/postgres/setup_pg10.sql
@@ -1,4 +1,10 @@
-CREATE ROLE ccp_monitoring WITH LOGIN;
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ccp_monitoring') THEN
+        CREATE ROLE ccp_monitoring WITH LOGIN;
+    END IF;
+END
+$$;
  
 GRANT pg_monitor to ccp_monitoring;
 

--- a/exporter/postgres/setup_pg11.sql
+++ b/exporter/postgres/setup_pg11.sql
@@ -1,4 +1,10 @@
-CREATE ROLE ccp_monitoring WITH LOGIN;
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ccp_monitoring') THEN
+        CREATE ROLE ccp_monitoring WITH LOGIN;
+    END IF;
+END
+$$;
  
 GRANT pg_monitor to ccp_monitoring;
 

--- a/exporter/postgres/setup_pg94.sql
+++ b/exporter/postgres/setup_pg94.sql
@@ -1,4 +1,10 @@
-CREATE ROLE ccp_monitoring WITH LOGIN;
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ccp_monitoring') THEN
+        CREATE ROLE ccp_monitoring WITH LOGIN;
+    END IF;
+END
+$$;
  
 CREATE SCHEMA IF NOT EXISTS monitor AUTHORIZATION ccp_monitoring;
 

--- a/exporter/postgres/setup_pg95.sql
+++ b/exporter/postgres/setup_pg95.sql
@@ -1,4 +1,10 @@
-CREATE ROLE ccp_monitoring WITH LOGIN;
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ccp_monitoring') THEN
+        CREATE ROLE ccp_monitoring WITH LOGIN;
+    END IF;
+END
+$$;
  
 CREATE SCHEMA IF NOT EXISTS monitor AUTHORIZATION ccp_monitoring;
 

--- a/exporter/postgres/setup_pg96.sql
+++ b/exporter/postgres/setup_pg96.sql
@@ -1,4 +1,10 @@
-CREATE ROLE ccp_monitoring WITH LOGIN;
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ccp_monitoring') THEN
+        CREATE ROLE ccp_monitoring WITH LOGIN;
+    END IF;
+END
+$$;
  
 CREATE SCHEMA IF NOT EXISTS monitor AUTHORIZATION ccp_monitoring;
 


### PR DESCRIPTION
Adding a check to see if the `ccp_monitoring` user exists prior to running the `CREATE ROLE` command to make the SQL idempotent.