### PR TITLE
use additional useradd options to skip doing things by hand

### DIFF
--- a/exporter/README.md
+++ b/exporter/README.md
@@ -15,7 +15,7 @@ The exporters below can be set up on any Linux-based system, but the instruction
 * See CHANGLOG.md file for full details on what has changed in this major version upgrade.
 * Many of the metric names in node_exporter v0.16.0 have had their names changed. All of the ones that pgmonitor uses in alerting and grafana related to CPU, Memory and Disk have been renamed. All files provided by pgmonitor 2.x have been updated to account for these changes so please either use these new files or see what has changed an incorporate them into your environment.
 * The symlink for the postgres_exporter sysconfig file is no longer being used. The symlink is removed as part of the upgrade, so the default postgres_exporter service that previously used this may have to be updated. See the `Enable Services` section below for the correct systemctl command to create the new service name. The old service can then be disabled/removed.
-* The `ccp_is_ready` check has been removed and pgmonitor now uses the `pg_up` check built into postgres_exporter. Prometheus alerting and grafana dashboards have been updated to account for this. 
+* The `ccp_is_ready` check has been removed and pgmonitor now uses the `pg_up` check built into postgres_exporter. Prometheus alerting and grafana dashboards have been updated to account for this.
 * A new metric `ccp_is_in_recovery` is used to help determine the primary/replica state of a given database in the grafana dashboards. The query for this can be found in queries_common.sql
 
 ### Installation on RHEL/CentOS 7
@@ -32,8 +32,8 @@ If you install the below available packages with RPM, you can continue reading a
 |--------------------------------|---------------------------------------------------------------------------|
 | node_exporter                  | Base package for node_exporter                                            |
 | postgres_exporter              | Base package for postgres_exporter                                        |
-| pgmonitor-pg##-extras          | Crunchy optimized configurations for postgres_exporter. Note that each major version of PostgreSQL has its own extras package (pgmonitor-pg96-extras, pgmonitor-pg10-extras, etc) | 
-| pgmonitor-node_exporter-extras | Crunchy optimized configurations for node_exporter                        | 
+| pgmonitor-pg##-extras          | Crunchy optimized configurations for postgres_exporter. Note that each major version of PostgreSQL has its own extras package (pgmonitor-pg96-extras, pgmonitor-pg10-extras, etc) |
+| pgmonitor-node_exporter-extras | Crunchy optimized configurations for node_exporter                        |
 | pg_bloat_check                 | Package for pg_bloat_check script                                         |
 
 #### Without Packages
@@ -51,15 +51,7 @@ For non-package installations, the exporters & pg_bloat_check can be downloaded 
 You will need to create a user named `ccp_monitoring` which you can do with the following command:
 
 ```bash
-sudo useradd ccp_monitoring
-```
-
-Create a folder in `/var/lib/` and set its permissions as such:
-
-```bash
-sudo mkdir /var/lib/ccp_monitoring
-sudo chmod 0700 /var/lib/ccp_monitoring
-sudo chown ccp_monitoring /var/lib/ccp_monitoring
+sudo useradd -m -d /var/lib/ccp_monitoring ccp_monitoring
 ```
 
 ##### Configuration File Installation
@@ -116,7 +108,7 @@ If you need to modify them, see the notes in the files for more details and reco
 - `/etc/sysconfig/node_exporter`
 - `/etc/sysconfig/postgres_exporter_pg##`
 
-Note that `/etc/sysconfig/postgres_exporter_pg##` is the default sysconfig file for monitoring the database running on the default port 5432 and connects to the "postgres" database. If you've installed the pgmonitor setup to a different database, modify this file accordingly or make a new one. If you make a new one, ensure the service name you enable references this file (see the Enable Services section below ). 
+Note that `/etc/sysconfig/postgres_exporter_pg##` is the default sysconfig file for monitoring the database running on the default port 5432 and connects to the "postgres" database. If you've installed the pgmonitor setup to a different database, modify this file accordingly or make a new one. If you make a new one, ensure the service name you enable references this file (see the Enable Services section below ).
 
 #### Database Configuration
 


### PR DESCRIPTION
If we use some additional `useradd` options then we don't need to `mkdir` or `chown` by hand