### PR TITLE
Fix hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ please view the
 
 ## Sponsors
 
-![Crunchy Data](/hugo/static/images/crunchy_logo.png)
+[![Crunchy Data](/hugo/static/images/crunchy_logo.png)](https://www.crunchydata.com/)
 
 [Crunchy Data](https://www.crunchydata.com/) is pleased to sponsor pgMonitor and many other [open-source projects](https://github.com/CrunchyData/) to help promote support the PostgreSQL community and software ecosystem.
 

--- a/hugo/content/_index.md
+++ b/hugo/content/_index.md
@@ -82,7 +82,7 @@ For the [full history](/changelog) of pgMonitor, please see the [CHANGELOG](/cha
 
 ## Sponsors
 
-![Crunchy Data](/images/crunchy_logo.png)
+[![Crunchy Data](/images/crunchy_logo.png)](https://www.crunchydata.com/)
 
 [Crunchy Data](https://www.crunchydata.com/) is pleased to sponsor pgMonitor and many other [open-source projects](https://github.com/CrunchyData/) to help promote support the PostgreSQL community and software ecosystem.
 


### PR DESCRIPTION
Rather than showing image, goto crunchydata.com when click on crunchy logo in Sponsors sections.