### PR TITLE
Fixing pgnodes var name bug

### DIFF
--- a/grafana/PGBouncer.json
+++ b/grafana/PGBouncer.json
@@ -443,7 +443,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ccp_pgbouncer_servers_server_state_count{job=\"[[pgnode]]\", conn_pool=\"[[conn_pool]]\"}",
+          "expr": "ccp_pgbouncer_servers_server_state_count{job=\"[[pgnodes]]\", conn_pool=\"[[conn_pool]]\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{server_state}}",


### PR DESCRIPTION
The dashboard uses `[[pgnode]]` for the server state count graph. This results in no data since the var should be `[[pgnodes]]` (plural).