### PR TITLE
Reverting CODEOWNERS back to individual team members

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @CrunchyData/solutionsengineering
+*   @dtseiler @hunleyd @keithf4 @sharmay


### PR DESCRIPTION
Github teams method didn't work as planned