### PR TITLE
Fix syntax error in PG prometheus rules file

### DIFF
--- a/prometheus/alert-rules.d/crunchy-alert-rules-pg.yml.example
+++ b/prometheus/alert-rules.d/crunchy-alert-rules-pg.yml.example
@@ -285,7 +285,7 @@ groups:
         description: 'Count of sequences on instance {{ $labels.job }} at over 75% usage: {{ $value }}. Run following query to see full sequence status: SELECT * FROM monitor.sequence_status() WHERE percent >= 75'
 
   - alert: PGSettingsPendingRestart
-    exper: ccp_settings_pending_restart_count > 0
+    expr: ccp_settings_pending_restart_count > 0
     for: 60s
     labels: 
         service: postgresql


### PR DESCRIPTION
# Description  

Typo in the `crunchy-alert-rules-pg.yml.example` file causes prometheus to fail starting when it's put in place as is. This was introduced in new changes to pgMonitor 4.2/HA 1.8

## Type of change  
Please check all options that are relevant  
- [x] Bug fix (change which fixes an issue)  
- [ ] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  

**Tested Configuration**:  
- [x] CentOS, Specify version(s):  7
- [x] PostgreQL, Specify version(s):  11
- [ ] docs tested with hugo <0.60  

Tested with playbook(s):  `crunchy-ha-postgresql-3-node`


