### PR TITLE
Container related updates to Prometheus Configs

### DIFF
--- a/exporter/postgres/queries_nodemx.yml
+++ b/exporter/postgres/queries_nodemx.yml
@@ -1,6 +1,6 @@
 ###
 #
-# Begin File: pod_metrics.yml
+# Begin File: queries_nodemx.yml
 #
 ###
 ccp_nodemx_network:
@@ -151,6 +151,6 @@ ccp_nodemx_data_disk:
 
 ###
 #
-# End File: pod_metrics.yml
+# End File: queries_nodemx.yml
 #
 ###

--- a/prometheus/crunchy-prometheus.yml.containers
+++ b/prometheus/crunchy-prometheus.yml.containers
@@ -5,12 +5,12 @@ global:
   evaluation_interval: 5s
 
 scrape_configs:
-- job_name: 'crunchy-collect'
+- job_name: 'crunchy-postgres-exporter'
   kubernetes_sd_configs:
   - role: pod
 
   relabel_configs:
-  - source_labels: [__meta_kubernetes_pod_label_crunchy_collect]
+  - source_labels: [__meta_kubernetes_pod_label_crunchy_postgres_exporter]
     action: keep
     regex: true
   - source_labels: [__meta_kubernetes_pod_container_port_number]


### PR DESCRIPTION
# Description  

The 'Crunchy Collect' container has been moved from the Crunchy Containers project to the Postgres
Operator project and renamed to 'Crunchy Postgres Exporter'. This PR updates the Prometheus config file used 
for container deployments to match the new container name.

Also, it updates the beginning and ending comments from referring to 'pod_metrics.yml' to 
the current name, 'queries_nodemx.yml'.


Fixes (issue) #  

Depends on (issue) #  

## Type of change  
Please check all options that are relevant  
- [x] Bug fix (change which fixes an issue)  
- [ ] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  

**Tested Configuration**:  
- [x] CentOS, Specify version(s):  7
- [x] PostgreQL, Specify version(s):  12.3
- [ ] docs tested with hugo <0.60  

Tested with playbook(s):  
# Checklist:  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  

