### PR TITLE
Update crunchy-prometheus.yml.containers to include all rules.yml dir

### DIFF
--- a/prometheus/crunchy-prometheus.yml.containers
+++ b/prometheus/crunchy-prometheus.yml.containers
@@ -63,4 +63,4 @@ scrape_configs:
     replacement: 'pg'
 
 rule_files:
-  - /conf/crunchy-alert-rules.yml
+  - /etc/prometheus/alert-rules.d/*.yml


### PR DESCRIPTION
This change updates the `rule_files` section of the prometheus config to include all rules files in a given directory. This will allow container users to mount a directory of alerting rules files to the container and have each file pulled in. This also follows how the base [crunchy-prometheus.yml](https://github.com/CrunchyData/pgmonitor/blob/82a1e39f5126cc7a77ee3ad55654f51e59263c23/prometheus/crunchy-prometheus.yml#L70) is setup.

# Description  

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes (issue) #  

Depends on (issue) #  

## Type of change  
Please check all options that are relevant  
- [ ] Bug fix (change which fixes an issue)  
- [ ] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  

**Tested Configuration**:  
- [x] CentOS, Specify version(s):  7
- [ ] PostgreQL, Specify version(s):  
- [ ] docs tested with hugo <0.60  

Tested with playbook(s):  
# Checklist:  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  

