### PR TITLE
Updates to container dashboards

### DIFF
--- a/grafana/containers/crud_details.json
+++ b/grafana/containers/crud_details.json
@@ -102,7 +102,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(ccp_stat_user_tables_n_tup_ins{pg_cluster=\"[[cluster]]\", instance=~\"[[pod]]\", dbname =~ \"[[dbname]]\", schemaname =~ \"[[schemaname]]\", relname=~\"[[tablename]]\"}[60s]))",
+          "expr": "sum(rate(ccp_stat_user_tables_n_tup_ins{pg_cluster=\"[[cluster]]\", pod=~\"[[pod]]\", dbname=~\"[[dbname]]\", schemaname=~\"[[schemaname]]\", relname=~\"[[tablename]]\"}[60s]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "inserts - [[dbname]].[[schemaname]].[[tablename]]",
@@ -110,7 +110,7 @@
           "step": 60
         },
         {
-          "expr": "sum(rate(ccp_stat_user_tables_n_tup_upd{pg_cluster=\"[[cluster]]\", instance=~\"[[pod]]\", dbname =~ \"[[dbname]]\", schemaname =~ \"[[schemaname]]\", relname=~\"[[tablename]]\"}[60s]))",
+          "expr": "sum(rate(ccp_stat_user_tables_n_tup_upd{pg_cluster=\"[[cluster]]\", pod=~\"[[pod]]\", dbname=~\"[[dbname]]\", schemaname=~\"[[schemaname]]\", relname=~\"[[tablename]]\"}[60s]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Updates - [[dbname]].[[schemaname]].[[tablename]]",
@@ -118,7 +118,7 @@
           "step": 60
         },
         {
-          "expr": "sum(rate(ccp_stat_user_tables_n_tup_del{pg_cluster=\"[[cluster]]\", instance=~\"[[pod]]\", dbname =~ \"[[dbname]]\", schemaname =~ \"[[schemaname]]\", relname=~\"[[tablename]]\"}[60s]))",
+          "expr": "sum(rate(ccp_stat_user_tables_n_tup_del{pg_cluster=\"[[cluster]]\", pod=~\"[[pod]]\", dbname=~\"[[dbname]]\", schemaname=~\"[[schemaname]]\", relname=~\"[[tablename]]\"}[60s]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Deletes - [[dbname]].[[schemaname]].[[tablename]]",
@@ -224,7 +224,7 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(ccp_database_size_bytes{pg_cluster=\"[[cluster]]\", instance=\"[[pod]]\"},dbname)",
+        "definition": "label_values(ccp_database_size_bytes{pg_cluster=\"[[cluster]]\"},dbname)",
         "hide": 0,
         "includeAll": true,
         "index": -1,
@@ -232,7 +232,7 @@
         "multi": true,
         "name": "dbname",
         "options": [],
-        "query": "label_values(ccp_database_size_bytes{pg_cluster=\"[[cluster]]\", instance=\"[[pod]]\"},dbname)",
+        "query": "label_values(ccp_database_size_bytes{pg_cluster=\"[[cluster]]\"},dbname)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -278,7 +278,7 @@
         "multi": true,
         "name": "tablename",
         "options": [],
-        "query": "label_values(ccp_stat_user_tables_n_tup_ins{pg_cluster=\"[[cluster]]\",instance=\"[[pod]]\",dbname=\"[[dbname]]\",schemaname=\"[[schemaname]]\"},relname)",
+        "query": "label_values(ccp_stat_user_tables_n_tup_ins{pg_cluster=\"[[cluster]]\",dbname=\"[[dbname]]\",schemaname=\"[[schemaname]]\"},relname)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/grafana/containers/crud_details.json
+++ b/grafana/containers/crud_details.json
@@ -52,6 +52,7 @@
     {
       "icon": "external link",
       "includeVars": true,
+      "keepTime": true,
       "tags": [],
       "type": "dashboards"
     }
@@ -255,7 +256,7 @@
         "multi": true,
         "name": "schemaname",
         "options": [],
-        "query": "label_values(ccp_stat_user_tables_n_tup_ins{pg_cluster=\"[[cluster]]\",dbname=\"[[dbname]]\"},schemaname)",
+        "query": "label_values(ccp_stat_user_tables_n_tup_ins{pg_cluster=\"[[cluster]]\",dbname=~\"[[dbname]]\"},schemaname)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -278,7 +279,7 @@
         "multi": true,
         "name": "tablename",
         "options": [],
-        "query": "label_values(ccp_stat_user_tables_n_tup_ins{pg_cluster=\"[[cluster]]\",dbname=\"[[dbname]]\",schemaname=\"[[schemaname]]\"},relname)",
+        "query": "label_values(ccp_stat_user_tables_n_tup_ins{pg_cluster=\"[[cluster]]\",dbname=~\"[[dbname]]\",schemaname=~\"[[schemaname]]\"},relname)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/grafana/containers/crud_details.json
+++ b/grafana/containers/crud_details.json
@@ -43,7 +43,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,

--- a/grafana/containers/pgbackrest.json
+++ b/grafana/containers/pgbackrest.json
@@ -55,7 +55,6 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [],
-      "targetBlank": true,
       "title": "",
       "type": "dashboards"
     }

--- a/grafana/containers/pgbackrest.json
+++ b/grafana/containers/pgbackrest.json
@@ -43,7 +43,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,

--- a/grafana/containers/pod_details.json
+++ b/grafana/containers/pod_details.json
@@ -52,6 +52,8 @@
     {
       "$$hashKey": "object:200",
       "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
       "tags": [],
       "type": "dashboards"
     }
@@ -99,7 +101,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(ccp_nodemx_data_disk_total_bytes{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"}-ccp_nodemx_data_disk_available_bytes{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"})*100/ccp_nodemx_data_disk_total_bytes{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"}",
+          "expr": "(ccp_nodemx_data_disk_total_bytes{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}-ccp_nodemx_data_disk_available_bytes{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})*100/ccp_nodemx_data_disk_total_bytes{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -107,7 +109,7 @@
           "refId": "A"
         },
         {
-          "expr": "(ccp_nodemx_data_disk_total_file_nodes{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"}-ccp_nodemx_data_disk_free_file_nodes{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"})*100/ccp_nodemx_data_disk_total_file_nodes{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"}",
+          "expr": "(ccp_nodemx_data_disk_total_file_nodes{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}-ccp_nodemx_data_disk_free_file_nodes{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})*100/ccp_nodemx_data_disk_total_file_nodes{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -200,7 +202,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(ccp_nodemx_data_disk_sectors_read{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"}[1m])*512",
+          "expr": "rate(ccp_nodemx_data_disk_sectors_read{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}[1m])*512",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -208,7 +210,7 @@
           "refId": "A"
         },
         {
-          "expr": "rate(ccp_nodemx_data_disk_sectors_written{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"}[1m])*512",
+          "expr": "rate(ccp_nodemx_data_disk_sectors_written{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}[1m])*512",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -303,7 +305,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ccp_nodemx_mem_limit{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"}",
+          "expr": "ccp_nodemx_mem_limit{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -311,7 +313,7 @@
           "refId": "A"
         },
         {
-          "expr": "ccp_nodemx_mem_request{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"}",
+          "expr": "ccp_nodemx_mem_request{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -319,7 +321,7 @@
           "refId": "B"
         },
         {
-          "expr": "ccp_nodemx_mem_cache{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"}",
+          "expr": "ccp_nodemx_mem_cache{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -327,7 +329,7 @@
           "refId": "C"
         },
         {
-          "expr": "ccp_nodemx_mem_dirty{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"}",
+          "expr": "ccp_nodemx_mem_dirty{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -335,7 +337,7 @@
           "refId": "D"
         },
         {
-          "expr": "ccp_nodemx_mem_shmem{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"}",
+          "expr": "ccp_nodemx_mem_shmem{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -343,7 +345,7 @@
           "refId": "E"
         },
         {
-          "expr": "ccp_nodemx_mem_rss{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"}",
+          "expr": "ccp_nodemx_mem_rss{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -351,7 +353,7 @@
           "refId": "F"
         },
         {
-          "expr": "ccp_nodemx_mem_mapped_file{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"}",
+          "expr": "ccp_nodemx_mem_mapped_file{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -359,7 +361,7 @@
           "refId": "G"
         },
         {
-          "expr": "ccp_nodemx_mem_active_anon{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"}",
+          "expr": "ccp_nodemx_mem_active_anon{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -367,7 +369,7 @@
           "refId": "H"
         },
         {
-          "expr": "ccp_nodemx_mem_inactive_anon{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"}",
+          "expr": "ccp_nodemx_mem_inactive_anon{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -375,7 +377,7 @@
           "refId": "I"
         },
         {
-          "expr": "ccp_nodemx_mem_active_file{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"}",
+          "expr": "ccp_nodemx_mem_active_file{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -383,7 +385,7 @@
           "refId": "J"
         },
         {
-          "expr": "ccp_nodemx_mem_inactive_file{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"}",
+          "expr": "ccp_nodemx_mem_inactive_file{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -482,7 +484,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(((rate(ccp_nodemx_cpuacct_usage{pg_cluster=\"[[cluster]]\",pod=\"[[pod]]\"}[1m]))/1000)*100)/((ccp_nodemx_cpucfs_quota_us{pg_cluster=\"[[cluster]]\",pod=\"[[pod]]\"}/ccp_nodemx_cpucfs_period_us{pg_cluster=\"[[cluster]]\",pod=\"[[pod]]\"})*1000*1000)",
+          "expr": "(((rate(ccp_nodemx_cpuacct_usage{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}[1m]))/1000)*100)/((ccp_nodemx_cpucfs_quota_us{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}/ccp_nodemx_cpucfs_period_us{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})*1000*1000)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -491,7 +493,7 @@
           "refId": "A"
         },
         {
-          "expr": "rate(ccp_nodemx_cpustat_nr_throttled{pg_cluster=\"[[cluster]]\",pod=\"[[pod]]\"}[1m])*100/rate(ccp_nodemx_cpustat_nr_periods{pg_cluster=\"[[cluster]]\",pod=\"[[pod]]\"}[1m])",
+          "expr": "rate(ccp_nodemx_cpustat_nr_throttled{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}[1m])*100/rate(ccp_nodemx_cpustat_nr_periods{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}[1m])",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -500,7 +502,7 @@
           "refId": "B"
         },
         {
-          "expr": "ccp_nodemx_process_count{pg_cluster=\"[[cluster]]\",pod=\"[[pod]]\"}",
+          "expr": "ccp_nodemx_process_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -592,7 +594,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(ccp_nodemx_network_rx_bytes{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\", interface!=\"tunl0\"}[1m])",
+          "expr": "rate(ccp_nodemx_network_rx_bytes{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\", interface!=\"tunl0\"}[1m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -600,7 +602,7 @@
           "refId": "A"
         },
         {
-          "expr": "rate(ccp_nodemx_network_tx_bytes{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\", interface!=\"tunl0\"}[1m])",
+          "expr": "rate(ccp_nodemx_network_tx_bytes{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\", interface!=\"tunl0\"}[1m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -707,7 +709,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ccp_nodemx_cpu_limit{pg_cluster=\"[[cluster]]\",pod=\"[[pod]]\"}",
+          "expr": "ccp_nodemx_cpu_limit{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -715,7 +717,7 @@
           "refId": "A"
         },
         {
-          "expr": "ccp_nodemx_cpu_request{pg_cluster=\"[[cluster]]\",pod=\"[[pod]]\"}",
+          "expr": "ccp_nodemx_cpu_request{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -723,7 +725,7 @@
           "refId": "B"
         },
         {
-          "expr": "ccp_nodemx_mem_limit{pg_cluster=\"[[cluster]]\",pod=\"[[pod]]\"}",
+          "expr": "ccp_nodemx_mem_limit{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -731,7 +733,7 @@
           "refId": "C"
         },
         {
-          "expr": "ccp_nodemx_mem_request{pg_cluster=\"[[cluster]]\",pod=\"[[pod]]\"}",
+          "expr": "ccp_nodemx_mem_request{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -816,10 +818,10 @@
         "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values({pg_cluster=\"[[cluster]]\"},pod)",
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
         "index": -1,
         "label": "pod",
-        "multi": false,
+        "multi": true,
         "name": "pod",
         "options": [],
         "query": "label_values({pg_cluster=\"[[cluster]]\"},pod)",

--- a/grafana/containers/pod_details.json
+++ b/grafana/containers/pod_details.json
@@ -43,7 +43,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,

--- a/grafana/containers/postgresql_details.json
+++ b/grafana/containers/postgresql_details.json
@@ -49,7 +49,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,

--- a/grafana/containers/postgresql_details.json
+++ b/grafana/containers/postgresql_details.json
@@ -990,7 +990,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ccp_replication_lag_size_bytes{pg_cluster=\"[[cluster]]\", service!~\".*replica\"}",
+          "expr": "ccp_replication_lag_size_bytes{pg_cluster=\"[[cluster]]\", role!=\"replica\"}",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -999,7 +999,7 @@
           "refId": "B"
         },
         {
-          "expr": "ccp_replication_lag_replay_time{pg_cluster=\"[[cluster]]\", service=~\".*replica\"}",
+          "expr": "ccp_replication_lag_replay_time{pg_cluster=\"[[cluster]]\", role=\"replica\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,

--- a/grafana/containers/postgresql_details.json
+++ b/grafana/containers/postgresql_details.json
@@ -61,7 +61,6 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [],
-      "targetBlank": true,
       "title": "",
       "type": "dashboards"
     }
@@ -218,7 +217,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(pg_stat_activity_count{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"active\"})*100/sum(pg_settings_max_connections{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"})",
+          "expr": "sum(pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"active\"})*100/sum(pg_settings_max_connections{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -302,7 +301,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(pg_stat_activity_count{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"idle in transaction\"})/sum(pg_settings_max_connections{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"})",
+          "expr": "sum(pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"idle in transaction\"})/sum(pg_settings_max_connections{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "B"
@@ -382,7 +381,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(pg_stat_activity_count{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"idle\"})*100/sum(pg_settings_max_connections{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"})",
+          "expr": "sum(pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"idle\"})*100/sum(pg_settings_max_connections{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "metric": "pg_stat_activity_count",
@@ -453,7 +452,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(pg_stat_database_xact_commit{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\"}[5m])) + sum(irate(pg_stat_database_xact_rollback{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\"}[5m]))",
+          "expr": "sum(irate(pg_stat_database_xact_commit{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\"}[5m])) + sum(irate(pg_stat_database_xact_rollback{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\"}[5m]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -554,7 +553,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (state) (pg_stat_activity_count{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"idle\"})",
+          "expr": "sum by (state) (pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"idle\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -565,7 +564,7 @@
           "step": 2
         },
         {
-          "expr": "sum by (state) (pg_stat_activity_count{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"idle in transaction\"})",
+          "expr": "sum by (state) (pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"idle in transaction\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -573,7 +572,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum by (state) (pg_stat_activity_count{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"active\"})",
+          "expr": "sum by (state) (pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"active\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "active",
@@ -1092,7 +1091,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(pg_stat_database_deadlocks{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\"}[5m]))",
+          "expr": "sum(rate(pg_stat_database_deadlocks{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\"}[5m]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -1102,7 +1101,7 @@
           "step": 2
         },
         {
-          "expr": "sum(rate(pg_stat_database_conflicts{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\"}[5m]))",
+          "expr": "sum(rate(pg_stat_database_conflicts{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "DeadLocks",
@@ -1296,7 +1295,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(ccp_stat_bgwriter_buffers_alloc{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"})",
+          "expr": "sum(ccp_stat_bgwriter_buffers_alloc{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Allocated",
@@ -1305,7 +1304,7 @@
           "step": 2
         },
         {
-          "expr": "sum(ccp_stat_bgwriter_buffers_backend{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"})",
+          "expr": "sum(ccp_stat_bgwriter_buffers_backend{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Backend",
@@ -1314,7 +1313,7 @@
           "step": 2
         },
         {
-          "expr": "sum(ccp_stat_bgwriter_buffers_backend_fsync{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"})",
+          "expr": "sum(ccp_stat_bgwriter_buffers_backend_fsync{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "FSync",
@@ -1323,7 +1322,7 @@
           "step": 2
         },
         {
-          "expr": "sum(ccp_stat_bgwriter_buffers_checkpoint{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"})",
+          "expr": "sum(ccp_stat_bgwriter_buffers_checkpoint{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "CheckPoint",
@@ -1332,7 +1331,7 @@
           "step": 2
         },
         {
-          "expr": "sum(ccp_stat_bgwriter_buffers_clean{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\"})",
+          "expr": "sum(ccp_stat_bgwriter_buffers_clean{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Clean",
@@ -1426,7 +1425,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(pg_stat_database_xact_commit{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\"}[5m]))",
+          "expr": "sum(irate(pg_stat_database_xact_commit{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Commit",
@@ -1435,7 +1434,7 @@
           "step": 2
         },
         {
-          "expr": "sum(irate(pg_stat_database_xact_rollback{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\"}[5m]))",
+          "expr": "sum(irate(pg_stat_database_xact_rollback{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Rollback",
@@ -1527,7 +1526,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (mode) (pg_locks_count{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",mode=\"accessexclusivelock\"})",
+          "expr": "sum by (mode) (pg_locks_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",mode=\"accessexclusivelock\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -1536,7 +1535,7 @@
           "step": 2
         },
         {
-          "expr": "sum by (mode) (pg_locks_count{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",mode=\"exclusivelock\"})",
+          "expr": "sum by (mode) (pg_locks_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",mode=\"exclusivelock\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -1545,7 +1544,7 @@
           "step": 2
         },
         {
-          "expr": "sum by (mode) (pg_locks_count{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",mode=\"rowexclusivelock\"})",
+          "expr": "sum by (mode) (pg_locks_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",mode=\"rowexclusivelock\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -1554,7 +1553,7 @@
           "step": 2
         },
         {
-          "expr": "sum by (mode) (pg_locks_count{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",mode=\"sharerowexclusivelock\"})",
+          "expr": "sum by (mode) (pg_locks_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",mode=\"sharerowexclusivelock\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -1563,7 +1562,7 @@
           "step": 2
         },
         {
-          "expr": "sum by (mode) (pg_locks_count{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",mode=\"shareupdateexclusivelock\"})",
+          "expr": "sum by (mode) (pg_locks_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",mode=\"shareupdateexclusivelock\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -1572,7 +1571,7 @@
           "step": 2
         },
         {
-          "expr": "sum by (mode) (pg_locks_count{pg_cluster=~\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",mode=\"accesssharelock\"})",
+          "expr": "sum by (mode) (pg_locks_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",mode=\"accesssharelock\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{mode}}",
@@ -1637,7 +1636,7 @@
         "includeAll": false,
         "index": -1,
         "label": "cluster",
-        "multi": true,
+        "multi": false,
         "name": "cluster",
         "options": [],
         "query": "label_values(pg_cluster)",
@@ -1680,7 +1679,7 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values({pg_cluster=\"[[cluster]]\" ,pod=\"[[pod]]\"},dbname)",
+        "definition": "label_values({pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"},dbname)",
         "hide": 0,
         "includeAll": true,
         "index": -1,
@@ -1688,7 +1687,7 @@
         "multi": true,
         "name": "datname",
         "options": [],
-        "query": "label_values({pg_cluster=\"[[cluster]]\" ,pod=\"[[pod]]\"},dbname)",
+        "query": "label_values({pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"},dbname)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/grafana/containers/postgresql_overview.json
+++ b/grafana/containers/postgresql_overview.json
@@ -140,7 +140,7 @@
       "targets": [
         {
           "$hashKey": "object:243",
-          "expr": "sum(pg_up{pg_cluster=\"$cluster\"})*100+sum(ccp_is_in_recovery_status{pg_cluster=\"$cluster\"})",
+          "expr": "sum(pg_up{pg_cluster=~\"$cluster\"})*100+sum(ccp_is_in_recovery_status{pg_cluster=~\"$cluster\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -170,7 +170,7 @@
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values(pg_cluster)",
-        "hide": 2,
+        "hide": 1,
         "includeAll": true,
         "index": -1,
         "label": "cluster",

--- a/grafana/containers/postgresql_overview.json
+++ b/grafana/containers/postgresql_overview.json
@@ -43,7 +43,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,

--- a/grafana/containers/postgresql_service_health_overview.json
+++ b/grafana/containers/postgresql_service_health_overview.json
@@ -55,7 +55,6 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [],
-      "targetBlank": true,
       "title": "",
       "type": "dashboards"
     }

--- a/grafana/containers/postgresql_service_health_overview.json
+++ b/grafana/containers/postgresql_service_health_overview.json
@@ -105,7 +105,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ccp_connection_stats_total{service=\"[[service_name]]\"}*100/ccp_connection_stats_max_connections{service=\"[[service_name]]\"}",
+          "expr": "100 * ccp_connection_stats_total{pg_cluster=\"[[cluster]]\",role=\"[[role]]\"} / ccp_connection_stats_max_connections{pg_cluster=\"[[cluster]]\",role=\"[[role]]\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -114,7 +114,7 @@
           "refId": "C"
         },
         {
-          "expr": "(ccp_nodemx_data_disk_total_bytes{service=\"[[service_name]]\"}-ccp_nodemx_data_disk_available_bytes{service=\"[[service_name]]\"})*100/ccp_nodemx_data_disk_total_bytes{service=\"[[service_name]]\"}",
+          "expr": "100 - 100 * ccp_nodemx_data_disk_available_bytes{pg_cluster=\"[[cluster]]\",role=\"[[role]]\"} / ccp_nodemx_data_disk_total_bytes{pg_cluster=\"[[cluster]]\",role=\"[[role]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -207,21 +207,15 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(ccp_stat_database_xact_commit{service=\"[[service_name]]\"}[1m])) + sum(irate(ccp_stat_database_xact_rollback{service=\"[[service_name]]\"}[1m]))",
+          "expr": "  sum(irate(ccp_stat_database_xact_commit{pg_cluster=\"[[cluster]]\",role=\"[[role]]\"}[1m]))\n+ sum(irate(ccp_stat_database_xact_rollback{pg_cluster=\"[[cluster]]\",role=\"[[role]]\"}[1m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Transactions per minute",
           "refId": "A"
         },
         {
-          "expr": "sum(irate(ccp_query_count{service=\"[[service_name]]\"}[1m])) + sum(irate(ccp_query_count{service=\"[[service_name]]\"}[1m]))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Queries per minute",
-          "refId": "B"
-        },
-        {
-          "expr": "ccp_connection_stats_active{service=\"[[service_name]]\"}",
+          "expr": "ccp_connection_stats_active{pg_cluster=\"[[cluster]]\",role=\"[[role]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -315,41 +309,46 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(ccp_stat_database_xact_rollback{service=\"[[service_name]]\"}[1m]))",
+          "expr": "sum(irate(ccp_stat_database_xact_rollback{pg_cluster=\"[[cluster]]\",role=\"[[role]]\"}[1m]))",
           "format": "time_series",
           "hide": true,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Rollbacks",
           "refId": "A"
         },
         {
-          "expr": "sum(irate(ccp_stat_database_deadlocks{service=\"[[service_name]]\"}[1m]))",
+          "expr": "sum(irate(ccp_stat_database_deadlocks{pg_cluster=\"[[cluster]]\",role=\"[[role]]\"}[1m]))",
           "format": "time_series",
           "hide": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Deadlock ",
           "refId": "D"
         },
         {
-          "expr": "sum(irate(ccp_stat_database_conflicts{service=\"[[service_name]]\"}[1m]))",
+          "expr": "sum(irate(ccp_stat_database_conflicts{pg_cluster=\"[[cluster]]\",role=\"[[role]]\"}[1m]))",
           "format": "time_series",
           "hide": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Conflicts",
           "refId": "B"
         },
         {
-          "expr": "pg_exporter_last_scrape_error{service=\"[[service_name]]\"}",
+          "expr": "pg_exporter_last_scrape_error{pg_cluster=\"[[cluster]]\",role=\"[[role]]\"}",
           "format": "time_series",
           "hide": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "scrape error",
           "refId": "C"
         },
         {
-          "expr": "clamp_max(ccp_archive_command_status_seconds_since_last_fail{service=\"[[service_name]]\"},1)",
+          "expr": "clamp_max(ccp_archive_command_status_seconds_since_last_fail{pg_cluster=\"[[cluster]]\",role=\"[[role]]\"},1)",
           "format": "time_series",
           "hide": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "archive error",
           "refId": "E"
@@ -426,9 +425,7 @@
       },
       "lines": true,
       "linewidth": 1,
-      "links": [
-        {}
-      ],
+      "links": [],
       "nullPointMode": "null",
       "options": {
         "dataLinks": []
@@ -443,7 +440,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ccp_connection_stats_max_query_time{service=\"[[service_name]]\"}",
+          "expr": "ccp_connection_stats_max_query_time{pg_cluster=\"[[cluster]]\",role=\"[[role]]\"}",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -453,7 +450,7 @@
           "refId": "A"
         },
         {
-          "expr": "ccp_query_avg_latency{service=\"[[service_name]]\"}",
+          "expr": "ccp_query_avg_latency{pg_cluster=\"[[cluster]]\",role=\"[[role]]\"}",
           "format": "time_series",
           "hide": true,
           "instant": false,
@@ -516,15 +513,38 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(service)",
+        "definition": "label_values(pg_cluster)",
         "hide": 0,
         "includeAll": false,
         "index": -1,
-        "label": "service_name",
+        "label": null,
         "multi": false,
-        "name": "service_name",
+        "name": "cluster",
         "options": [],
-        "query": "label_values(service)",
+        "query": "label_values(pg_cluster)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_PROMETHEUS}",
+        "definition": "label_values({pg_cluster=\"[[cluster]]\"},role)",
+        "hide": 0,
+        "includeAll": false,
+        "index": -1,
+        "label": null,
+        "multi": false,
+        "name": "role",
+        "options": [],
+        "query": "label_values({pg_cluster=\"[[cluster]]\"},role)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/grafana/containers/postgresql_service_health_overview.json
+++ b/grafana/containers/postgresql_service_health_overview.json
@@ -43,7 +43,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,

--- a/grafana/containers/prometheus_alerts.json
+++ b/grafana/containers/prometheus_alerts.json
@@ -54,7 +54,6 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [],
-      "targetBlank": true,
       "title": "",
       "type": "dashboards"
     }

--- a/grafana/containers/prometheus_alerts.json
+++ b/grafana/containers/prometheus_alerts.json
@@ -190,7 +190,7 @@
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 2,
           "mappingType": 1,
-          "pattern": "crunchy_collect",
+          "pattern": "crunchy_postgres_exporter",
           "thresholds": [],
           "type": "hidden",
           "unit": "short"
@@ -377,23 +377,6 @@
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 2,
           "mappingType": 1,
-          "pattern": "service",
-          "thresholds": [],
-          "type": "hidden",
-          "unit": "short"
-        },
-        {
-          "alias": "",
-          "align": "auto",
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
           "pattern": "pgo_pg_database",
           "thresholds": [],
           "type": "hidden",
@@ -545,7 +528,7 @@
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 2,
           "mappingType": 1,
-          "pattern": "crunchy_collect",
+          "pattern": "crunchy_postgres_exporter",
           "thresholds": [],
           "type": "hidden",
           "unit": "short"

--- a/prometheus/crunchy-prometheus.yml.containers
+++ b/prometheus/crunchy-prometheus.yml.containers
@@ -40,9 +40,6 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_deployment_name]
     target_label: deployment
     replacement: '$1'
-  - source_labels: [__meta_kubernetes_pod_label_service_name]
-    target_label: service
-    replacement: '$1'
   - source_labels: [__meta_kubernetes_pod_label_role]
     target_label: role
     replacement: '$1'

--- a/prometheus/crunchy-prometheus.yml.containers
+++ b/prometheus/crunchy-prometheus.yml.containers
@@ -30,11 +30,7 @@ scrape_configs:
     target_label: kubernetes_namespace
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_name]
-    regex: (^[^-]*).*
-    target_label: instance
-    replacement: '$1'
-  - source_labels: [__meta_kubernetes_namespace,instance]
+  - source_labels: [__meta_kubernetes_namespace,__meta_kubernetes_pod_label_pg_cluster]
     target_label: pg_cluster
     separator: ':'
     replacement: '$1$2'


### PR DESCRIPTION
# Description  

These patches update the container scrapes and dashboards to better utilize the labels provided by Crunchy PostgreSQL Operator. Namely, the `pg_cluster` label is applied to all the instances that form a cluster and the Kubernetes Pod name suffices to identify an instance. The `service` and derived `instance` labels have been removed and replaced with the above.

Along the way, I updated the Grafana template variables to be consistently single- or multi-valued so that the current cluster and instance stay selected as one follows dashboard links.

Issue: [ch8765]

## Type of change  
Please check all options that are relevant  
- [x] Bug fix (change which fixes an issue)  

# How Has This Been Tested?  

**Tested Configuration**:  
- [x] CentOS, Specify version(s):  CentOS 7 containers
- [x] PostgreQL, Specify version(s):  PostgreSQL 12 containers
- [ ] docs tested with hugo <0.60  

Tested with ~playbook(s)~:  Crunchy PostgreSQL Operator
# Checklist:  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  

