### PR TITLE
Postgres exporter configuration updates related to the pgnodemx extension

### DIFF
--- a/exporter/postgres/queries_nodemx.yml
+++ b/exporter/postgres/queries_nodemx.yml
@@ -122,7 +122,7 @@ ccp_nodemx_data_disk:
         usage: "LABEL"
         description: "mount point"
     - fs_type:
-        usage: "GAUGE"
+        usage: "LABEL"
         description: "File system type"
     - reads:
         usage: "GAUGE"

--- a/exporter/postgres/setup_pg10.sql
+++ b/exporter/postgres/setup_pg10.sql
@@ -3,6 +3,12 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ccp_monitoring') THEN
         CREATE ROLE ccp_monitoring WITH LOGIN;
     END IF;
+
+    -- The pgmonitor role is required by the pgnodemx extension in PostgreSQL versions 9.5 and 9.6
+    -- and should be removed when upgrading to PostgreSQL 10 and above.
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'pgmonitor') THEN
+        DROP ROLE pgmonitor;
+    END IF;
 END
 $$;
  

--- a/exporter/postgres/setup_pg11.sql
+++ b/exporter/postgres/setup_pg11.sql
@@ -3,6 +3,12 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ccp_monitoring') THEN
         CREATE ROLE ccp_monitoring WITH LOGIN;
     END IF;
+
+    -- The pgmonitor role is required by the pgnodemx extension in PostgreSQL versions 9.5 and 9.6
+    -- and should be removed when upgrading to PostgreSQL 10 and above.
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'pgmonitor') THEN
+        DROP ROLE pgmonitor;
+    END IF;
 END
 $$;
  

--- a/exporter/postgres/setup_pg12.sql
+++ b/exporter/postgres/setup_pg12.sql
@@ -3,6 +3,12 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ccp_monitoring') THEN
         CREATE ROLE ccp_monitoring WITH LOGIN;
     END IF;
+
+    -- The pgmonitor role is required by the pgnodemx extension in PostgreSQL versions 9.5 and 9.6
+    -- and should be removed when upgrading to PostgreSQL 10 and above.
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'pgmonitor') THEN
+        DROP ROLE pgmonitor;
+    END IF;
 END
 $$;
  

--- a/exporter/postgres/setup_pg95.sql
+++ b/exporter/postgres/setup_pg95.sql
@@ -1,7 +1,12 @@
 DO $$
 BEGIN
+    -- The pgmonitor role is required by the pgnodemx extension in PostgreSQL versions 9.5 and 9.6
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'pgmonitor') THEN
+        CREATE ROLE pgmonitor;
+    END IF;
+
     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ccp_monitoring') THEN
-        CREATE ROLE ccp_monitoring WITH LOGIN;
+        CREATE ROLE ccp_monitoring WITH LOGIN IN ROLE pgmonitor;
     END IF;
 END
 $$;

--- a/exporter/postgres/setup_pg96.sql
+++ b/exporter/postgres/setup_pg96.sql
@@ -1,7 +1,12 @@
 DO $$
 BEGIN
+    -- The pgmonitor role is required by the pgnodemx extension in PostgreSQL versions 9.5 and 9.6
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'pgmonitor') THEN
+        CREATE ROLE pgmonitor;
+    END IF;
+
     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ccp_monitoring') THEN
-        CREATE ROLE ccp_monitoring WITH LOGIN;
+        CREATE ROLE ccp_monitoring WITH LOGIN IN ROLE pgmonitor;
     END IF;
 END
 $$;


### PR DESCRIPTION
# Description  
This PR has two updates. 

For the first, the fs_type usage value for ccp_nodemx_data_disk causes an error in the relevant logs:

"Could not parse string: strconv.ParseFloat: parsing \"xfs\": invalid syntax" source="postgres_exporter.go:739"
"Unexpected error parsing column:  ccp_nodemx_data_disk fs_type xfs\n" source="postgres_exporter.go:1361"
    
To correct this, the fs_type usage value has been updated to "LABEL" in place of "GAUGE".

For the second, per the pgnodemx documentation:
"PostgreSQL version 9.5 or newer is required. On PostgreSQL version 9.6 or earlier, a role called
pgmonitor must be created, and the user calling these functions must be granted that role."

As such, the 'pgmonitor' role has been added to the 'setup_pg95.sql' and 'setup_pg96.sql' exporter scripts.
Please note, no such change was added to the PG 9.4 equivalent due to incompatibility with the pgnodemx extension.


Fixes (issue) #  

Depends on (issue) #  

## Type of change  
Please check all options that are relevant  
- [x] Bug fix (change which fixes an issue)  
- [ ] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  

**Tested Configuration**:  
- [x] CentOS, Specify version(s):  Centos 7 containers
- [x] PostgreQL, Specify version(s):  9.6.19 and 9.5.23
- [ ] docs tested with hugo <0.60  

Tested with playbook(s):  
# Checklist:  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  

