### PR TITLE
Add metric for monitoring for blocked queries

### DIFF
--- a/exporter/postgres/queries_pg10.yml
+++ b/exporter/postgres/queries_pg10.yml
@@ -11,6 +11,7 @@ ccp_connection_stats:
         , idle_in_txn
         , (select coalesce(extract(epoch from (max(now() - state_change))),0) from pg_catalog.pg_stat_activity where state = 'idle in transaction') as max_idle_in_txn_time
         , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and state <> 'idle' ) as max_query_time
+        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and wait_event_type = 'Lock' ) as max_blocked_query_time
         , max_connections
         from (
                 select count(*) as total
@@ -36,6 +37,9 @@ ccp_connection_stats:
     - max_query_time:
         usage: "GAUGE"
         description: "Length of time in seconds of the longest running query"
+    - max_blocked_query_time:
+        usage: "GAUGE"
+        description: "Length of time in seconds of the longest running query that has been blocked by a heavyweight lock"
     - max_connections:
         usage: "GAUGE"
         description: "Value of max_connections for the monitored database"

--- a/exporter/postgres/queries_pg11.yml
+++ b/exporter/postgres/queries_pg11.yml
@@ -11,6 +11,8 @@ ccp_connection_stats:
         , idle_in_txn
         , (select coalesce(extract(epoch from (max(now() - state_change))),0) from pg_catalog.pg_stat_activity where state = 'idle in transaction') as max_idle_in_txn_time
         , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and state <> 'idle' ) as max_query_time
+        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and wait_event_type = 'Lock' ) as max_blocked_query_time
+        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from monitor.pg_stat_activity() where waiting = 't' ) as max_blocked_query_time
         , max_connections
         from (
                 select count(*) as total
@@ -36,6 +38,9 @@ ccp_connection_stats:
     - max_query_time:
         usage: "GAUGE"
         description: "Length of time in seconds of the longest running query"
+    - max_blocked_query_time:
+        usage: "GAUGE"
+        description: "Length of time in seconds of the longest running query that has been blocked by a heavyweight lock"
     - max_connections:
         usage: "GAUGE"
         description: "Value of max_connections for the monitored database"

--- a/exporter/postgres/queries_pg11.yml
+++ b/exporter/postgres/queries_pg11.yml
@@ -12,7 +12,6 @@ ccp_connection_stats:
         , (select coalesce(extract(epoch from (max(now() - state_change))),0) from pg_catalog.pg_stat_activity where state = 'idle in transaction') as max_idle_in_txn_time
         , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and state <> 'idle' ) as max_query_time
         , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and wait_event_type = 'Lock' ) as max_blocked_query_time
-        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from monitor.pg_stat_activity() where waiting = 't' ) as max_blocked_query_time
         , max_connections
         from (
                 select count(*) as total

--- a/exporter/postgres/queries_pg12.yml
+++ b/exporter/postgres/queries_pg12.yml
@@ -11,6 +11,7 @@ ccp_connection_stats:
         , idle_in_txn
         , (select coalesce(extract(epoch from (max(now() - state_change))),0) from pg_catalog.pg_stat_activity where state = 'idle in transaction') as max_idle_in_txn_time
         , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and state <> 'idle' ) as max_query_time
+        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and wait_event_type = 'Lock' ) as max_blocked_query_time
         , max_connections
         from (
                 select count(*) as total
@@ -36,6 +37,9 @@ ccp_connection_stats:
     - max_query_time:
         usage: "GAUGE"
         description: "Length of time in seconds of the longest running query"
+    - max_blocked_query_time:
+        usage: "GAUGE"
+        description: "Length of time in seconds of the longest running query that has been blocked by a heavyweight lock"
     - max_connections:
         usage: "GAUGE"
         description: "Value of max_connections for the monitored database"

--- a/exporter/postgres/queries_pg13.yml
+++ b/exporter/postgres/queries_pg13.yml
@@ -11,6 +11,7 @@ ccp_connection_stats:
         , idle_in_txn
         , (select coalesce(extract(epoch from (max(now() - state_change))),0) from pg_catalog.pg_stat_activity where state = 'idle in transaction') as max_idle_in_txn_time
         , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and state <> 'idle' ) as max_query_time
+        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and wait_event_type = 'Lock' ) as max_blocked_query_time
         , max_connections
         from (
                 select count(*) as total
@@ -36,6 +37,9 @@ ccp_connection_stats:
     - max_query_time:
         usage: "GAUGE"
         description: "Length of time in seconds of the longest running query"
+    - max_blocked_query_time:
+        usage: "GAUGE"
+        description: "Length of time in seconds of the longest running query that has been blocked by a heavyweight lock"
     - max_connections:
         usage: "GAUGE"
         description: "Value of max_connections for the monitored database"

--- a/exporter/postgres/queries_pg95.yml
+++ b/exporter/postgres/queries_pg95.yml
@@ -11,6 +11,7 @@ ccp_connection_stats:
         , idle_in_txn
         , (select coalesce(extract(epoch from (max(now() - state_change))),0) from monitor.pg_stat_activity() where state = 'idle in transaction') as max_idle_in_txn_time
         , (select coalesce(extract(epoch from (max(now() - query_start))),0) from monitor.pg_stat_activity() where state <> 'idle') as max_query_time
+        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from monitor.pg_stat_activity() where waiting = 't' ) as max_blocked_query_time
         , max_connections
         from (
                 select count(*) as total
@@ -36,6 +37,9 @@ ccp_connection_stats:
     - max_query_time:
         usage: "GAUGE"
         description: "Length of time in seconds of the longest running query"
+    - max_blocked_query_time:
+        usage: "GAUGE"
+        description: "Length of time in seconds of the longest running query that has been blocked by a heavyweight lock"
     - max_connections:
         usage: "GAUGE"
         description: "Value of max_connections for the monitored database"

--- a/exporter/postgres/queries_pg96.yml
+++ b/exporter/postgres/queries_pg96.yml
@@ -12,6 +12,7 @@ ccp_connection_stats:
         , idle_in_txn
         , (select coalesce(extract(epoch from (max(now() - state_change))),0) from monitor.pg_stat_activity() where state = 'idle in transaction') as max_idle_in_txn_time
         , (select coalesce(extract(epoch from (max(now() - query_start))),0) from monitor.pg_stat_activity() where state <> 'idle') as max_query_time
+        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and wait_event_type = 'Lock' ) as max_blocked_query_time
         , max_connections
         from (
                 select count(*) as total
@@ -37,6 +38,9 @@ ccp_connection_stats:
     - max_query_time:
         usage: "GAUGE"
         description: "Length of time in seconds of the longest running query"
+    - max_blocked_query_time:
+        usage: "GAUGE"
+        description: "Length of time in seconds of the longest running query that has been blocked by a heavyweight lock"
     - max_connections:
         usage: "GAUGE"
         description: "Value of max_connections for the monitored database"

--- a/hugo/content/changelog/_index.md
+++ b/hugo/content/changelog/_index.md
@@ -9,6 +9,7 @@ weight: 5
 
   * Added support for PostgreSQL 13 
   * Added queries and dashboards for pgnodemx/container support
+  * Added metrics for monitoring longest blocked query time
 
 ### Bug Fixes
 

--- a/hugo/content/exporter/_index.md
+++ b/hugo/content/exporter/_index.md
@@ -507,6 +507,8 @@ The following metrics either require special considerations when monitoring spec
 
  * *ccp_connection_stats_idle_in_txn* - Count of idle in transaction connections
 
+ * *ccp_connection_stats_max_blocked_query_time* - Runtime of longest running query that has been blocked by a heavyweight lock
+
  * *ccp_connection_stats_max_connections* - Current value of max_connections for reference
 
  * *ccp_connection_stats_max_idle_in_txn_time* - Runtime of longest idle in transaction (IIT) session. 


### PR DESCRIPTION
# Description  

Allow for monitoring the time for the longest running query that is blocked by a heavyweight lock

Fixes (issue) #  

Depends on (issue) #  

## Type of change  
Please check all options that are relevant  
- [ ] Bug fix (change which fixes an issue)  
- [x] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  

**Tested Configuration**:  
- [x] CentOS, Specify version(s):  CentOS7
- [x] PostgreQL, Specify version(s):  9.5, 11
- [x] docs tested with hugo <0.60  

Tested with playbook(s):  
# Checklist:  
- I have made corresponding changes to:  
    - [x] the documentation  
    - [x] the release notes  
    - [ ] the upgrade doc  

