### PR TITLE
Trim whitespace

### DIFF
--- a/prometheus/alert-rules.d/crunchy-alert-rules-blackbox.yml.example
+++ b/prometheus/alert-rules.d/crunchy-alert-rules-blackbox.yml.example
@@ -4,10 +4,10 @@ groups:
 
  ########## BLACKBOX EXPORTER RULES ##########
   - alert: BlackBoxProbe
-    expr: probe_success == 0  
+    expr: probe_success == 0
     for: 60s
     labels:
-      service: blackbox 
+      service: blackbox
       severity: critical
       severity_num: 300
     annotations:

--- a/prometheus/alert-rules.d/crunchy-alert-rules-etcd.yml.example
+++ b/prometheus/alert-rules.d/crunchy-alert-rules-etcd.yml.example
@@ -1,17 +1,17 @@
 groups:
 - name: alert-rules
   rules:
-      
+
 ########## ETCD EXPORTER RULES ##########
 
 # Absence alerts must be configured per named job, otherwise there's no way to know which job is down
 # Below is are some examples using the leader metric for a targets called "etcd#" for a 3 node etcd cluster
- 
+
 #  - alert: ECTDAbsent_etcd1
 #    expr: absent(etcd_server_has_leader{job="etcd1"})
 #    for: 10s
 #    labels:
-#      service: etcd 
+#      service: etcd
 #      severity: critical
 #      severity_num: 300
 #    annotations:
@@ -21,7 +21,7 @@ groups:
 #    expr: absent(etcd_server_has_leader{job="etcd2"})
 #    for: 10s
 #    labels:
-#      service: etcd 
+#      service: etcd
 #      severity: critical
 #      severity_num: 300
 #    annotations:
@@ -31,7 +31,7 @@ groups:
 #    expr: absent(etcd_server_has_leader{job="etcd3"})
 #    for: 10s
 #    labels:
-#      service: etcd 
+#      service: etcd
 #      severity: critical
 #      severity_num: 300
 #    annotations:

--- a/prometheus/alert-rules.d/crunchy-alert-rules-node.yml.example
+++ b/prometheus/alert-rules.d/crunchy-alert-rules-node.yml.example
@@ -1,13 +1,13 @@
 groups:
 - name: alert-rules
   rules:
-      
+
 ########## EXPORTER RULES ##########
   - alert: NodeExporterScrapeError
     expr: node_textfile_scrape_error > 0
     for: 60s
     labels:
-      service: system 
+      service: system
       severity: critical
       severity_num: 300
     annotations:
@@ -17,7 +17,7 @@ groups:
 ########## SYSTEM RULES ##########
   - alert: ExporterDown
     expr: avg_over_time(up[5m]) < 0.5
-    for: 10s 
+    for: 10s
     labels:
       service: system
       severity: critical

--- a/prometheus/alert-rules.d/crunchy-alert-rules-pg.yml.containers.example
+++ b/prometheus/alert-rules.d/crunchy-alert-rules-pg.yml.containers.example
@@ -1,7 +1,7 @@
 groups:
 - name: alert-rules
   rules:
-      
+
 ########## EXPORTER RULES ##########
   - alert: PGExporterScrapeError
     expr: pg_exporter_last_scrape_error > 0
@@ -45,8 +45,8 @@ groups:
 # Set this alert for each system that you want to monitor a recovery status change
 # Below is an example for a target job called "Replica" and watches for the value to change above 1 which means it's no longer a replica
 #
-#  - alert: PGRecoveryStatusSwitch_Replica 
-#    expr: ccp_is_in_recovery_status{job="Replica"} > 1 
+#  - alert: PGRecoveryStatusSwitch_Replica
+#    expr: ccp_is_in_recovery_status{job="Replica"} > 1
 #    for: 60s
 #    labels:
 #      service: postgresql
@@ -71,7 +71,7 @@ groups:
 
 # Optional monitor for changes to pg_settings (postgresql.conf) system catalog.
 # A similar metric is available for monitoring pg_hba.conf. See ccp_hba_settings_checksum().
-# If metric returns 0, then NO settings have changed for either pg_settings since last known valid state 
+# If metric returns 0, then NO settings have changed for either pg_settings since last known valid state
 # If metric returns 1, then pg_settings have changed since last known valid state
 # To see what may have changed, check the monitor.pg_settings_checksum table for a history of config state.
 #  - alert: PGSettingsChecksum
@@ -82,7 +82,7 @@ groups:
 #      severity: critical
 #      severity_num: 300
 #    annotations:
-#      description: 'Configuration settings on {{ $labels.job }} have changed from previously known valid state. To reset current config to a valid state after alert fires, run monitor.pg_settings_checksum_set_valid().' 
+#      description: 'Configuration settings on {{ $labels.job }} have changed from previously known valid state. To reset current config to a valid state after alert fires, run monitor.pg_settings_checksum_set_valid().'
 #      summary: 'PGSQL Instance settings checksum'
 
 
@@ -125,14 +125,14 @@ groups:
     for: 60s
     labels:
       service: postgresql
-      severity: warning 
+      severity: warning
       severity_num: 200
     annotations:
       description: '{{ $labels.job }} has at least one query running for over 12 hours.'
       summary: 'PGSQL Max Query Runtime'
 
   - alert: PGQueryTime
-    expr: ccp_connection_stats_max_query_time > 86400 
+    expr: ccp_connection_stats_max_query_time > 86400
     for: 60s
     labels:
       service: postgresql
@@ -154,7 +154,7 @@ groups:
       summary: 'PGSQL Instance connections'
 
   - alert: PGConnPerc
-    expr: 100 * (ccp_connection_stats_total / ccp_connection_stats_max_connections) > 90 
+    expr: 100 * (ccp_connection_stats_total / ccp_connection_stats_max_connections) > 90
     for: 60s
     labels:
       service: postgresql
@@ -287,7 +287,7 @@ groups:
   - alert: PGSettingsPendingRestart
     expr: ccp_settings_pending_restart_count > 0
     for: 60s
-    labels: 
+    labels:
         service: postgresql
         severity: critical
         severity_num: 300
@@ -296,14 +296,14 @@ groups:
 
 ########## PGBACKREST RULES ##########
 #
-# Uncomment and customize one or more of these rules to monitor your pgbackrest backups. 
+# Uncomment and customize one or more of these rules to monitor your pgbackrest backups.
 # Full backups are considered the equivalent of both differentials and incrementals since both are based on the last full
 #   And differentials are considered incrementals since incrementals will be based off the last diff if one exists
 #   This avoid false alerts, for example when you don't run diff/incr backups on the days that you run a full
-# Stanza should also be set if different intervals are expected for each stanza. 
+# Stanza should also be set if different intervals are expected for each stanza.
 #   Otherwise rule will be applied to all stanzas returned on target system if not set.
 #
-# Relevant metric names are: 
+# Relevant metric names are:
 #   ccp_backrest_last_full_time_since_completion_seconds
 #   ccp_backrest_last_incr_time_since_completion_seconds
 #   ccp_backrest_last_diff_time_since_completion_seconds
@@ -333,7 +333,7 @@ groups:
 #
 #   ccp_backrest_last_runtime_backup_runtime_seconds
 #
-# Runtime monitoring should have the "backup_type" label set. 
+# Runtime monitoring should have the "backup_type" label set.
 #   Otherwise the rule will apply to the last run of all backup types returned (full, diff, incr)
 # Stanza should also be set if runtimes per stanza have different expected times
 #
@@ -358,10 +358,10 @@ groups:
 #       summary: 'Expected runtime of diff backup for stanza [main] has exceeded 1 hour'
 ##
 #
-## If the pgbackrest command fails to run, the metric disappears from the exporter output and the alert never fires. 
+## If the pgbackrest command fails to run, the metric disappears from the exporter output and the alert never fires.
 ## An absence alert must be configured explicitly for each target (job) that backups are being monitored.
 ## Checking for absence of just the full backup type should be sufficient (no need for diff/incr).
-## Note that while the backrest check command failing will likely also cause a scrape error alert, the addition of this 
+## Note that while the backrest check command failing will likely also cause a scrape error alert, the addition of this
 ## check gives a clearer answer as to what is causing it and that something is wrong with the backups.
 #
 #  - alert: PGBackrestAbsentFull_Prod

--- a/prometheus/alert-rules.d/crunchy-alert-rules-pg.yml.example
+++ b/prometheus/alert-rules.d/crunchy-alert-rules-pg.yml.example
@@ -1,7 +1,7 @@
 groups:
 - name: alert-rules
   rules:
-      
+
 ########## EXPORTER RULES ##########
   - alert: PGExporterScrapeError
     expr: pg_exporter_last_scrape_error > 0
@@ -45,8 +45,8 @@ groups:
 # Set this alert for each system that you want to monitor a recovery status change
 # Below is an example for a target job called "Replica" and watches for the value to change above 1 which means it's no longer a replica
 #
-#  - alert: PGRecoveryStatusSwitch_Replica 
-#    expr: ccp_is_in_recovery_status{job="Replica"} > 1 
+#  - alert: PGRecoveryStatusSwitch_Replica
+#    expr: ccp_is_in_recovery_status{job="Replica"} > 1
 #    for: 60s
 #    labels:
 #      service: postgresql
@@ -71,7 +71,7 @@ groups:
 
 # Optional monitor for changes to pg_settings (postgresql.conf) system catalog.
 # A similar metric is available for monitoring pg_hba.conf. See ccp_hba_settings_checksum().
-# If metric returns 0, then NO settings have changed for either pg_settings since last known valid state 
+# If metric returns 0, then NO settings have changed for either pg_settings since last known valid state
 # If metric returns 1, then pg_settings have changed since last known valid state
 # To see what may have changed, check the monitor.pg_settings_checksum table for a history of config state.
 #  - alert: PGSettingsChecksum
@@ -82,7 +82,7 @@ groups:
 #      severity: critical
 #      severity_num: 300
 #    annotations:
-#      description: 'Configuration settings on {{ $labels.job }} have changed from previously known valid state. To reset current config to a valid state after alert fires, run monitor.pg_settings_checksum_set_valid().' 
+#      description: 'Configuration settings on {{ $labels.job }} have changed from previously known valid state. To reset current config to a valid state after alert fires, run monitor.pg_settings_checksum_set_valid().'
 #      summary: 'PGSQL Instance settings checksum'
 
 
@@ -125,14 +125,14 @@ groups:
     for: 60s
     labels:
       service: postgresql
-      severity: warning 
+      severity: warning
       severity_num: 200
     annotations:
       description: '{{ $labels.job }} has at least one query running for over 12 hours.'
       summary: 'PGSQL Max Query Runtime'
 
   - alert: PGQueryTime
-    expr: ccp_connection_stats_max_query_time > 86400 
+    expr: ccp_connection_stats_max_query_time > 86400
     for: 60s
     labels:
       service: postgresql
@@ -154,7 +154,7 @@ groups:
       summary: 'PGSQL Instance connections'
 
   - alert: PGConnPerc
-    expr: 100 * (ccp_connection_stats_total / ccp_connection_stats_max_connections) > 90 
+    expr: 100 * (ccp_connection_stats_total / ccp_connection_stats_max_connections) > 90
     for: 60s
     labels:
       service: postgresql
@@ -287,7 +287,7 @@ groups:
   - alert: PGSettingsPendingRestart
     expr: ccp_settings_pending_restart_count > 0
     for: 60s
-    labels: 
+    labels:
         service: postgresql
         severity: critical
         severity_num: 300
@@ -296,14 +296,14 @@ groups:
 
 ########## PGBACKREST RULES ##########
 #
-# Uncomment and customize one or more of these rules to monitor your pgbackrest backups. 
+# Uncomment and customize one or more of these rules to monitor your pgbackrest backups.
 # Full backups are considered the equivalent of both differentials and incrementals since both are based on the last full
 #   And differentials are considered incrementals since incrementals will be based off the last diff if one exists
 #   This avoid false alerts, for example when you don't run diff/incr backups on the days that you run a full
-# Stanza should also be set if different intervals are expected for each stanza. 
+# Stanza should also be set if different intervals are expected for each stanza.
 #   Otherwise rule will be applied to all stanzas returned on target system if not set.
 #
-# Relevant metric names are: 
+# Relevant metric names are:
 #   ccp_backrest_last_full_time_since_completion_seconds
 #   ccp_backrest_last_incr_time_since_completion_seconds
 #   ccp_backrest_last_diff_time_since_completion_seconds
@@ -333,7 +333,7 @@ groups:
 #
 #   ccp_backrest_last_runtime_backup_runtime_seconds
 #
-# Runtime monitoring should have the "backup_type" label set. 
+# Runtime monitoring should have the "backup_type" label set.
 #   Otherwise the rule will apply to the last run of all backup types returned (full, diff, incr)
 # Stanza should also be set if runtimes per stanza have different expected times
 #
@@ -358,10 +358,10 @@ groups:
 #       summary: 'Expected runtime of diff backup for stanza [main] has exceeded 1 hour'
 ##
 #
-## If the pgbackrest command fails to run, the metric disappears from the exporter output and the alert never fires. 
+## If the pgbackrest command fails to run, the metric disappears from the exporter output and the alert never fires.
 ## An absence alert must be configured explicitly for each target (job) that backups are being monitored.
 ## Checking for absence of just the full backup type should be sufficient (no need for diff/incr).
-## Note that while the backrest check command failing will likely also cause a scrape error alert, the addition of this 
+## Note that while the backrest check command failing will likely also cause a scrape error alert, the addition of this
 ## check gives a clearer answer as to what is causing it and that something is wrong with the backups.
 #
 #  - alert: PGBackrestAbsentFull_Prod


### PR DESCRIPTION
# Description  

This change gets rid of whitespace in the alerting rules files. The whitespace in the file was making the yml unreadable once mounted to a Kubernetes Configmap

```
groups:\n- name: alert-rules\n  rules:\n      \n##########
    EXPORTER RULES ##########\n  - alert: PGExporterScrapeError\n    expr: pg_exporter_last_scrape_error
    > 0\n    for: 60s\n    labels:\n      service: postgresql\n      severity: critical\n
    \     severity_num: 300\n    annotations:\n      summary: 'Postgres Exporter running
...
```

Once whitespace is removed
```
    groups:
    - name: alert-rules
      rules:

    ########## EXPORTER RULES ##########
      - alert: PGExporterScrapeError
        expr: pg_exporter_last_scrape_error > 0
        for: 60s
...
```

Fixes (issue) #  

Depends on (issue) #  

## Type of change  
Please check all options that are relevant  
- [x] Bug fix (change which fixes an issue)  
- [ ] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  

**Tested Configuration**:  
- [ ] CentOS, Specify version(s): 
- [ ] PostgreQL, Specify version(s):  
- [ ] docs tested with hugo <0.60  

Tested by mounting the `prometheus/alert-rules.d/crunchy-alert-rules-pg.yml.containers.example` file to the upstream Prometheus container. Prometheus was able to parse the file and the alerting rules showed up on the Alerts page. Other files were not tested.

Tested with playbook(s):  
# Checklist:  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  

