### PR TITLE
Fix query for connection metrics in PG96

### DIFF
--- a/exporter/postgres/queries_pg96.yml
+++ b/exporter/postgres/queries_pg96.yml
@@ -12,7 +12,7 @@ ccp_connection_stats:
         , idle_in_txn
         , (select coalesce(extract(epoch from (max(now() - state_change))),0) from monitor.pg_stat_activity() where state = 'idle in transaction') as max_idle_in_txn_time
         , (select coalesce(extract(epoch from (max(now() - query_start))),0) from monitor.pg_stat_activity() where state <> 'idle') as max_query_time
-        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and wait_event_type = 'Lock' ) as max_blocked_query_time
+        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where wait_event_type = 'Lock' ) as max_blocked_query_time
         , max_connections
         from (
                 select count(*) as total


### PR DESCRIPTION
# Description  

The backend_type column had not yet been added in PG 9.6 for the connection metrics. This was added when the blocked query time was added in an 4.4RC6.


## Type of change  
Please check all options that are relevant  
- [x] Bug fix (change which fixes an issue)  
- [ ] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  

**Tested Configuration**:  
- [x] CentOS, Specify version(s):  7
- [x] PostgreQL, Specify version(s):  9.6
- [ ] docs tested with hugo <0.60  

Tested with playbook(s):  
# Checklist:  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  

