### PR TITLE
Simplify alertmanager config to avoid errors on initial setup

### DIFF
--- a/prometheus/crunchy-alertmanager.yml
+++ b/prometheus/crunchy-alertmanager.yml
@@ -1,12 +1,22 @@
-# Simple example reference: https://github.com/prometheus/alertmanager/blob/master/doc/examples/simple.yml
+# Based on upstream example file found here: https://github.com/prometheus/alertmanager/blob/master/doc/examples/simple.yml
 global:
-    smtp_smarthost: 'smtp.example.com:587'
-    smtp_from: 'Alertmanager <abc@yahoo.com>'
-    smtp_auth_username: '<username>'
-    smtp_auth_password: '<password>'
+    smtp_smarthost: 'localhost: 25'
+    smtp_require_tls: false
+#    smtp_smarthost: 'smtp.example.com:587'
+#    smtp_from: 'Alertmanager <abc@yahoo.com>'
+#    smtp_auth_username: '<username>'
+#    smtp_auth_password: '<password>'
 
 # templates:
 # - '/etc/alertmanager/template/*.tmpl'
+
+inhibit_rules:
+# Apply inhibition of warning if the alertname for the same system and service is already critical
+- source_match:
+    severity: 'critical'
+  target_match:
+    severity: 'warning'
+  equal: ['alertname', 'job', 'service']
 
 receivers:
 - name: 'default-receiver'
@@ -14,33 +24,24 @@ receivers:
   - to: 'example@crunchydata.com'
     send_resolved: true
 
-- name: 'pagerduty-dba'
-  pagerduty_configs:
-      - service_key: <RANDOMKEYSTUFF>
+## Examples of alternative alert receivers. See documentation for more info on how to configure these fully
+#- name: 'pagerduty-dba'
+#  pagerduty_configs:
+#      - service_key: <RANDOMKEYSTUFF>
 
-- name: 'pagerduty-sre'
-  pagerduty_configs:
-      - service_key: <RANDOMKEYSTUFF>
+#- name: 'pagerduty-sre'
+#  pagerduty_configs:
+#      - service_key: <RANDOMKEYSTUFF>
 
-- name: 'dba-team'
-  email_configs:
-  - to: 'example-dba-team@crunchydata.com'
-    send_resolved: true
+#- name: 'dba-team'
+#  email_configs:
+#  - to: 'example-dba-team@crunchydata.com'
+#    send_resolved: true
 
-- name: 'sre-team'
-  email_configs:
-  - to: 'example-sre-team@crunchydata.com'
-    send_resolved: true
-
-
-inhibit_rules:
-- source_match:
-    severity: 'critical'
-  target_match:
-    severity: 'warning'
-  # Apply inhibition of warning if the alertname for the same system and service is already critical
-  equal: ['alertname', 'job', 'service']
-
+#- name: 'sre-team'
+#  email_configs:
+#  - to: 'example-sre-team@crunchydata.com'
+#    send_resolved: true
 
 route:
     receiver: default-receiver
@@ -49,25 +50,22 @@ route:
     group_interval: 5m
     repeat_interval: 24h
 
-    routes:
-    - match_re:
-        service: ^(postgresql|mysql|oracle)$
-      receiver: dba-team
-      # sub route to send critical dba alerts to pagerduty
-      routes:
-      - match:
-          severity: critical
-        receiver: pagerduty-dba
-
-    - match:
-        service: system
-      receiver: sre-team
-      # sub route to send critical sre alerts to pagerduty
-      routes:
-      - match:
-          severity: critical
-        receiver: pagerduty-sre
-
-
-
-
+## Example routes to show how to route outgoing alerts based on the content of that alert
+#    routes:
+#    - match_re:
+#        service: ^(postgresql|mysql|oracle)$
+#      receiver: dba-team
+#      # sub route to send critical dba alerts to pagerduty
+#      routes:
+#      - match:
+#          severity: critical
+#        receiver: pagerduty-dba
+#
+#    - match:
+#        service: system
+#      receiver: sre-team
+#      # sub route to send critical sre alerts to pagerduty
+#      routes:
+#      - match:
+#          severity: critical
+#        receiver: pagerduty-sre


### PR DESCRIPTION
# Description  

Current provided alertmanager config has options which will cause errors during initial setup if not fixed or commented out. Comment these out by default and provide a config that should "just work" in most situations if a local smtp provider is available.

Fixes (issue) #192 

## Type of change  
Please check all options that are relevant  
- [x] Bug fix (change which fixes an issue)  
- [ ] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  

**Tested Configuration**:  
- [ ] CentOS, Specify version(s):  
- [ ] PostgreQL, Specify version(s):  
- [ ] docs tested with hugo <0.60  

Tested with playbook(s):  
# Checklist:  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  

