### PR TITLE
Add automatic failover alert

### DIFF
--- a/prometheus/alert-rules.d/crunchy-alert-rules-pg.yml.example
+++ b/prometheus/alert-rules.d/crunchy-alert-rules-pg.yml.example
@@ -38,9 +38,8 @@ groups:
 #    annotations:
 #      summary: '{{ $labels.job }} is not running at least version 11.5 of PostgreSQL'
 
-# Monitor for a failover event by watching for the recovery status value to change within specified time period
-# IMPORTANT NOTE: This alert will automatically resolve after the given offset time period has passed. 
-# If a permanent failover alert that requires manual intervention to resolve is required, see the commented out alert (beneath this one) for configuring failover monitoring per named job
+# Monitor for a failover event by checking if the recovery status value has changed within the specified time period
+# IMPORTANT NOTE: This alert will *automatically resolve* after the given offset time period has passed! If you desire to have an alert that must be manually resolved, see the commented out alert beneath this one
 - alert: PGRecoveryStatusSwitch
   expr: ccp_is_in_recovery_status != ccp_is_in_recovery_status offset 5m 
   for: 60s

--- a/prometheus/alert-rules.d/crunchy-alert-rules-pg.yml.example
+++ b/prometheus/alert-rules.d/crunchy-alert-rules-pg.yml.example
@@ -38,6 +38,18 @@ groups:
 #    annotations:
 #      summary: '{{ $labels.job }} is not running at least version 11.5 of PostgreSQL'
 
+# Monitor for a failover event by watching for the recovery status value to change within specified time period
+# IMPORTANT NOTE: This alert will automatically resolve after the given offset time period has passed. 
+# If a permanent failover alert that requires manual intervention to resolve is required, see the following commented out alert for configuring failover monitoring per named job
+- alert: PGRecoveryStatusSwitch
+  expr: ccp_is_in_recovery_status != ccp_is_in_recovery_status offset 5m 
+  for: 60s
+  labels:
+    service: postgresql
+    severity: critical
+    severity_num: 300
+  annotations:
+    summary: '{{ $labels.job }} has had a PostgreSQL failover event. Please check systems involved in this cluster for more details'
 
 # Whether a system switches from primary to replica or vice versa must be configured per named job.
 # No way to tell what value a system is supposed to be without a rule expression for that specific system

--- a/prometheus/alert-rules.d/crunchy-alert-rules-pg.yml.example
+++ b/prometheus/alert-rules.d/crunchy-alert-rules-pg.yml.example
@@ -40,7 +40,7 @@ groups:
 
 # Monitor for a failover event by watching for the recovery status value to change within specified time period
 # IMPORTANT NOTE: This alert will automatically resolve after the given offset time period has passed. 
-# If a permanent failover alert that requires manual intervention to resolve is required, see the following commented out alert for configuring failover monitoring per named job
+# If a permanent failover alert that requires manual intervention to resolve is required, see the commented out alert (beneath this one) for configuring failover monitoring per named job
 - alert: PGRecoveryStatusSwitch
   expr: ccp_is_in_recovery_status != ccp_is_in_recovery_status offset 5m 
   for: 60s
@@ -385,5 +385,4 @@ groups:
 #      severity_num: 300
 #    annotations:
 #      description: 'Backup Full status missing for Prod. Check that pgbackrest info command is working on target system.'
-
 


### PR DESCRIPTION
# Description  

Include a default alert rule that can alert on any failover occurrence. 

Fixes (issue) #180 

## Type of change  
Please check all options that are relevant  
- [ ] Bug fix (change which fixes an issue)  
- [x] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  

**Tested Configuration**:  
- [x] CentOS, Specify version(s):  CentOS7
- [x] PostgreQL, Specify version(s):  11
- [ ] docs tested with hugo <0.60  

Tested with playbook(s):  
# Checklist:  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  

