### PR TITLE
Fix spacing to satisfy yml formatting

### DIFF
--- a/prometheus/alert-rules.d/crunchy-alert-rules-pg.yml.example
+++ b/prometheus/alert-rules.d/crunchy-alert-rules-pg.yml.example
@@ -40,15 +40,15 @@ groups:
 
 # Monitor for a failover event by checking if the recovery status value has changed within the specified time period
 # IMPORTANT NOTE: This alert will *automatically resolve* after the given offset time period has passed! If you desire to have an alert that must be manually resolved, see the commented out alert beneath this one
-- alert: PGRecoveryStatusSwitch
-  expr: ccp_is_in_recovery_status != ccp_is_in_recovery_status offset 5m 
-  for: 60s
-  labels:
-    service: postgresql
-    severity: critical
-    severity_num: 300
-  annotations:
-    summary: '{{ $labels.job }} has had a PostgreSQL failover event. Please check systems involved in this cluster for more details'
+  - alert: PGRecoveryStatusSwitch
+    expr: ccp_is_in_recovery_status != ccp_is_in_recovery_status offset 5m 
+    for: 60s
+    labels:
+      service: postgresql
+      severity: critical
+      severity_num: 300
+    annotations:
+      summary: '{{ $labels.job }} has had a PostgreSQL failover event. Please check systems involved in this cluster for more details'
 
 # Whether a system switches from primary to replica or vice versa must be configured per named job.
 # No way to tell what value a system is supposed to be without a rule expression for that specific system


### PR DESCRIPTION
# Description  

Invalid spacing was causing promtool validation of alert rules for pg to fail. Introduced in PR #219 so not a bug in previous released versions.

## Type of change  
Please check all options that are relevant  
- [x] Bug fix (change which fixes an issue)  
- [ ] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  

**Tested Configuration**:  
- [x] CentOS, Specify version(s):  7
- [x] PostgreQL, Specify version(s):  13
- [ ] docs tested with hugo <0.60  

Tested with playbook(s):  
# Checklist:  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  

