### PR TITLE
Disable the disk fill predict alert by default

### DIFF
--- a/prometheus/linux/alert-rules.d/crunchy-alert-rules-node.yml.example
+++ b/prometheus/linux/alert-rules.d/crunchy-alert-rules-node.yml.example
@@ -52,16 +52,6 @@ groups:
     annotations:
       description: 'Disk usage on target {{ $labels.job }} at {{ $value }}%'
 
-  - alert: DiskFillPredict
-    expr: predict_linear(node_filesystem_free_bytes{device!~"tmpfs|by-uuid",fstype=~"xfs|ext[234]"}[1h], 4 * 3600) < 0
-    for: 5m
-    labels:
-      service: system
-      severity: warning
-      severity_num: 200
-    annotations:
-      description: '(EXPERIMENTAL) Disk {{ $labels.device }} on target {{ $labels.job }} is predicted to fill in 4 hrs based on current usage'
-
   - alert: SystemLoad5m
     expr: node_load5 > 5
     for: 10m
@@ -122,3 +112,12 @@ groups:
     annotations:
       description: 'Swap usage for target {{ $labels.job }} is at {{ $value }}%'
 
+#  - alert: DiskFillPredict
+#    expr: predict_linear(node_filesystem_free_bytes{device!~"tmpfs|by-uuid",fstype=~"xfs|ext[234]"}[1h], 4 * 3600) < 0
+#    for: 5m
+#    labels:
+#      service: system
+#      severity: warning
+#      severity_num: 200
+#    annotations:
+#      description: 'Disk {{ $labels.device }} on target {{ $labels.job }} is predicted to fill in 4 hrs based on current usage'


### PR DESCRIPTION
# Description  

Disable the disk fill prediction alert. It had been marked experimental and generally requires tuning to not cause false alerts.

## Type of change  
Please check all options that are relevant  
- [ ] Bug fix (change which fixes an issue)  
- [x] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  

**Tested Configuration**:  
- [x] CentOS, Specify version(s):  CentOS7
- [ ] PostgreQL, Specify version(s):  
- [ ] docs tested with hugo <0.60  

Tested with playbook(s):  
# Checklist:  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  

