### PR TITLE
Update Grafana dashboards for 7.4. Incorporate Container changes

### DIFF
--- a/grafana/common/Bloat_Details.json
+++ b/grafana/common/Bloat_Details.json
@@ -415,16 +415,6 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
     "time_options": [
       "5m",
       "15m",

--- a/grafana/common/Bloat_Details.json
+++ b/grafana/common/Bloat_Details.json
@@ -15,8 +15,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 9,
-  "iteration": 1582574684659,
+  "iteration": 1618857609712,
   "links": [],
   "panels": [
     {
@@ -25,6 +24,13 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -49,9 +55,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -61,10 +68,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(ccp_bloat_check_total_wasted_space_bytes{job=~\"[[pgnodes]]\"})/sum(ccp_bloat_check_size_bytes{job=~\"[[pgnodes]]\"})*100",
+          "expr": "sum(ccp_bloat_check_total_wasted_space_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\"})/sum(ccp_bloat_check_size_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\"})*100",
           "format": "time_series",
           "hide": false,
+          "interval": "",
           "intervalFactor": 1,
+          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -88,6 +97,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:117",
           "format": "percent",
           "label": null,
           "logBase": 1,
@@ -96,6 +106,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:118",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -115,6 +126,13 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -141,9 +159,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -153,8 +172,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ccp_bloat_check_total_wasted_space_bytes{job=~\"[[pgnodes]]\", dbname=\"[[dbname]]\", schemaname=\"[[schemaname]]\",objectname=\"[[objectname]]\"}",
+          "expr": "ccp_bloat_check_total_wasted_space_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\", dbname=\"[[pgdatabase]]\", schemaname=\"[[schemaname]]\",objectname=\"[[objectname]]\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{schemaname}}.{{objectname}}",
           "refId": "A",
@@ -181,6 +201,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:202",
           "format": "decbytes",
           "label": null,
           "logBase": 1,
@@ -189,6 +210,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:203",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -208,6 +230,13 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -234,9 +263,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -246,8 +276,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ccp_bloat_check_total_wasted_space_bytes{job=~\"[[pgnodes]]\", dbname=\"[[dbname]]\"} > 10240",
+          "expr": "ccp_bloat_check_total_wasted_space_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\", dbname=\"[[pgdatabase]]\"} > 10240",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{dbname}}.{{schemaname}}.{{objectname}}",
           "refId": "A",
@@ -274,6 +305,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:289",
           "format": "decbytes",
           "label": null,
           "logBase": 1,
@@ -282,6 +314,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:290",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -297,7 +330,7 @@
     }
   ],
   "refresh": "15m",
-  "schemaVersion": 21,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -305,22 +338,34 @@
       {
         "allValue": null,
         "current": {
-          "text": "pg1",
-          "value": "pg1"
+          "selected": false,
+          "text": "crunchy",
+          "value": "crunchy"
         },
-        "datasource": "PROMETHEUS",
-        "definition": "",
+        "datasource": null,
+        "definition": "label_values(up{exp_type='pg'}, cluster_name)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "PGCluster",
         "multi": false,
-        "name": "pgnodes",
-        "options": [],
-        "query": "label_values(up{exp_type='pg'}, job)",
-        "refresh": 1,
+        "name": "pgcluster",
+        "options": [
+          {
+            "selected": true,
+            "text": "crunchy",
+            "value": "crunchy"
+          }
+        ],
+        "query": {
+          "query": "label_values(up{exp_type='pg'}, cluster_name)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 0,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 1,
+        "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",
@@ -330,20 +375,24 @@
       {
         "allValue": null,
         "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
+          "selected": true,
+          "text": "crunchy_pg1_crunchy",
+          "value": "crunchy_pg1_crunchy"
         },
         "datasource": "PROMETHEUS",
-        "definition": "",
+        "definition": "label_values(up{exp_type='pg', cluster_name=\"[[pgcluster]]\"}, job)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
-        "label": null,
+        "label": "Node",
         "multi": false,
-        "name": "dbname",
+        "name": "pgnodes",
         "options": [],
-        "query": "label_values(ccp_bloat_check_total_wasted_space_bytes{job=~\"[[pgnodes]]\"},dbname)",
+        "query": {
+          "query": "label_values(up{exp_type='pg', cluster_name=\"[[pgcluster]]\"}, job)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -357,20 +406,55 @@
       {
         "allValue": null,
         "current": {
-          "isNone": true,
           "selected": false,
-          "text": "None",
-          "value": ""
+          "text": "testdb",
+          "value": "testdb"
         },
         "datasource": "PROMETHEUS",
-        "definition": "",
+        "definition": "label_values(ccp_bloat_check_total_wasted_space_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\"},dbname)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "PGDatabase",
+        "multi": false,
+        "name": "pgdatabase",
+        "options": [],
+        "query": {
+          "query": "label_values(ccp_bloat_check_total_wasted_space_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\"},dbname)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "information_schema",
+          "value": "information_schema"
+        },
+        "datasource": "PROMETHEUS",
+        "definition": "label_values(ccp_bloat_check_total_wasted_space_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\",dbname=\"[[pgdatabase]]\"},schemaname)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "schemaname",
         "options": [],
-        "query": "label_values(ccp_bloat_check_total_wasted_space_bytes{job=\"[[pgnodes]]\",dbname=\"[[dbname]]\"},schemaname)",
+        "query": {
+          "query": "label_values(ccp_bloat_check_total_wasted_space_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\",dbname=\"[[pgdatabase]]\"},schemaname)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -384,20 +468,24 @@
       {
         "allValue": null,
         "current": {
-          "isNone": true,
           "selected": false,
-          "text": "None",
-          "value": ""
+          "text": "sql_features",
+          "value": "sql_features"
         },
         "datasource": "PROMETHEUS",
-        "definition": "",
+        "definition": "label_values(ccp_bloat_check_total_wasted_space_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\",dbname=\"[[pgdatabase]]\",schemaname=\"[[schemaname]]\"}, objectname)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "objectname",
         "options": [],
-        "query": "label_values(ccp_bloat_check_total_wasted_space_bytes{job=~\"[[pgnodes]]\",dbname=\"[[dbname]]\",schemaname=\"[[schemaname]]\"}, objectname)",
+        "query": {
+          "query": "label_values(ccp_bloat_check_total_wasted_space_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\",dbname=\"[[pgdatabase]]\",schemaname=\"[[schemaname]]\"}, objectname)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/grafana/common/CRUD_Details.json
+++ b/grafana/common/CRUD_Details.json
@@ -15,8 +15,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 2,
-  "iteration": 1582574775669,
+  "iteration": 1618857086778,
   "links": [],
   "panels": [
     {
@@ -25,6 +24,13 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -49,9 +55,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -61,24 +68,27 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(ccp_stat_user_tables_n_tup_ins{job=~\"[[pgnodes]]\", dbname = \"[[dbname]]\", schemaname = \"[[schemaname]]\", relname=\"[[tablename]]\"}[60s])",
+          "expr": "rate(ccp_stat_user_tables_n_tup_ins{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname = \"[[pgdatabase]]\", schemaname = \"[[schemaname]]\", relname=\"[[tablename]]\"}[60s])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "inserts - {{dbname}}.{{schemaname}}.{{relname}}",
           "refId": "A",
           "step": 60
         },
         {
-          "expr": "rate(ccp_stat_user_tables_n_tup_upd{job=~\"[[pgnodes]]\", dbname = \"[[dbname]]\", schemaname = \"[[schemaname]]\", relname=\"[[tablename]]\"}[60s])",
+          "expr": "rate(ccp_stat_user_tables_n_tup_upd{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname = \"[[pgdatabase]]\", schemaname = \"[[schemaname]]\", relname=\"[[tablename]]\"}[60s])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "updates - {{dbname}}.{{schemaname}}.{{relname}}",
           "refId": "B",
           "step": 60
         },
         {
-          "expr": "rate(ccp_stat_user_tables_n_tup_del{job=~\"[[pgnodes]]\", dbname = \"[[dbname]]\", schemaname = \"[[schemaname]]\", relname=\"[[tablename]]\"}[60s])",
+          "expr": "rate(ccp_stat_user_tables_n_tup_del{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname = \"[[pgdatabase]]\", schemaname = \"[[schemaname]]\", relname=\"[[tablename]]\"}[60s])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "deletes - {{dbname}}.{{schemaname}}.{{relname}}",
           "refId": "C",
@@ -105,6 +115,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:366",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -113,6 +124,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:367",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -128,7 +140,7 @@
     }
   ],
   "refresh": "15m",
-  "schemaVersion": 21,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -136,18 +148,24 @@
       {
         "allValue": null,
         "current": {
-          "text": "pg1",
-          "value": "pg1"
+          "selected": false,
+          "text": "crunchy",
+          "value": "crunchy"
         },
         "datasource": "PROMETHEUS",
-        "definition": "",
+        "definition": "label_values(up{exp_type='pg'}, cluster_name)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "PGCluster",
         "multi": false,
-        "name": "pgnodes",
+        "name": "pgcluster",
         "options": [],
-        "query": "label_values(up{exp_type='pg'}, job)",
+        "query": {
+          "query": "label_values(up{exp_type='pg'}, cluster_name)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -161,18 +179,24 @@
       {
         "allValue": null,
         "current": {
-          "text": "postgres",
-          "value": "postgres"
+          "selected": false,
+          "text": "crunchy_pg1_crunchy",
+          "value": "crunchy_pg1_crunchy"
         },
         "datasource": "PROMETHEUS",
-        "definition": "",
+        "definition": "label_values(up{exp_type='pg', cluster_name=\"[[pgcluster]]\"}, job)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
-        "label": null,
+        "label": "Node",
         "multi": false,
-        "name": "dbname",
+        "name": "pgnodes",
         "options": [],
-        "query": "label_values(ccp_database_size_bytes{job=~\"[[pgnodes]]\"},dbname)",
+        "query": {
+          "query": "label_values(up{exp_type='pg', cluster_name=\"[[pgcluster]]\"}, job)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -186,20 +210,55 @@
       {
         "allValue": null,
         "current": {
-          "isNone": true,
           "selected": false,
-          "text": "None",
-          "value": ""
+          "text": "testdb",
+          "value": "testdb"
         },
         "datasource": "PROMETHEUS",
-        "definition": "",
+        "definition": "label_values(ccp_stat_user_tables_n_tup_ins{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\"}, dbname)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "PGDatabase",
+        "multi": false,
+        "name": "pgdatabase",
+        "options": [],
+        "query": {
+          "query": "label_values(ccp_stat_user_tables_n_tup_ins{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\"}, dbname)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "public",
+          "value": "public"
+        },
+        "datasource": "PROMETHEUS",
+        "definition": "label_values(ccp_stat_user_tables_n_tup_ins{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\",dbname=\"[[pgdatabase]]\"},schemaname)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "schemaname",
         "options": [],
-        "query": "label_values(ccp_stat_user_tables_n_tup_ins{job=~\"[[pgnodes]]\",dbname=\"[[dbname]]\"},schemaname)",
+        "query": {
+          "query": "label_values(ccp_stat_user_tables_n_tup_ins{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\",dbname=\"[[pgdatabase]]\"},schemaname)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -213,20 +272,24 @@
       {
         "allValue": null,
         "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
+          "selected": true,
+          "text": "bloat_tables",
+          "value": "bloat_tables"
         },
         "datasource": "PROMETHEUS",
-        "definition": "",
+        "definition": "label_values(ccp_stat_user_tables_n_tup_ins{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\",dbname=\"[[pgdatabase]]\",schemaname=\"[[schemaname]]\"},relname)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "tablename",
         "options": [],
-        "query": "label_values(ccp_stat_user_tables_n_tup_ins{job=~\"[[pgnodes]]\",dbname=\"[[dbname]]\",schemaname=\"[[schemaname]]\"},relname)",
+        "query": {
+          "query": "label_values(ccp_stat_user_tables_n_tup_ins{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\",dbname=\"[[pgdatabase]]\",schemaname=\"[[schemaname]]\"},relname)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/grafana/common/CRUD_Details.json
+++ b/grafana/common/CRUD_Details.json
@@ -244,16 +244,6 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
     "time_options": [
       "5m",
       "15m",

--- a/grafana/common/ETCD_Details.json
+++ b/grafana/common/ETCD_Details.json
@@ -1851,16 +1851,6 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
     "time_options": [
       "5m",
       "15m",

--- a/grafana/common/PGBackrest.json
+++ b/grafana/common/PGBackrest.json
@@ -654,17 +654,10 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-14d",
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
     "time_options": [
       "5m",
       "15m",

--- a/grafana/common/PGBackrest.json
+++ b/grafana/common/PGBackrest.json
@@ -15,10 +15,72 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 4,
-  "iteration": 1614244309467,
+  "iteration": 1618256102636,
   "links": [],
   "panels": [
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "dtdhms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "valueSize": 45
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.5",
+      "targets": [
+        {
+          "expr": "time()- ccp_backrest_oldest_full_backup_time_seconds{stanza=\"[[backrest_stanza]]\"} + on(job,instance) group_left() (ccp_is_in_recovery_status == 2)",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Recovery Window",
+      "type": "stat"
+    },
     {
       "aliasColors": {},
       "bars": false,
@@ -38,7 +100,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 3
       },
       "hiddenSeries": false,
       "id": 2,
@@ -47,7 +109,8 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "rightSide": true,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -59,7 +122,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -73,15 +136,33 @@
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{stanza}}",
+          "legendFormat": "incr",
           "refId": "A"
+        },
+        {
+          "expr": "ccp_backrest_last_diff_backup_time_since_completion_seconds{stanza=\"[[backrest_stanza]]\"} + on(job,instance) group_left() (ccp_is_in_recovery_status == 2)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "diff",
+          "refId": "B"
+        },
+        {
+          "expr": "ccp_backrest_last_full_backup_time_since_completion_seconds{stanza=\"[[backrest_stanza]]\"} + on(job,instance) group_left() (ccp_is_in_recovery_status == 2)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "full",
+          "refId": "C"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Time Since Last Completed Backup (Any)",
+      "title": "Time Since Last Completed Backup",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -97,6 +178,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:96",
           "format": "s",
           "label": null,
           "logBase": 1,
@@ -105,6 +187,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:97",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -137,7 +220,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 0
+        "y": 3
       },
       "hiddenSeries": false,
       "id": 4,
@@ -146,6 +229,7 @@
         "current": false,
         "max": false,
         "min": false,
+        "rightSide": true,
         "show": true,
         "total": false,
         "values": false
@@ -158,7 +242,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -180,7 +264,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Backup Runtime (Any)",
+      "title": "Last Backup Runtime",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -196,6 +280,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:197",
           "format": "s",
           "label": null,
           "logBase": 1,
@@ -204,6 +289,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:198",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -236,7 +322,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 8
+        "y": 11
       },
       "hiddenSeries": false,
       "id": 8,
@@ -245,6 +331,7 @@
         "current": false,
         "max": false,
         "min": false,
+        "rightSide": true,
         "show": true,
         "total": false,
         "values": false
@@ -257,7 +344,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.4.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -279,7 +366,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Backup Size (Total)",
+      "title": "Last Backup Size (Total)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -295,6 +382,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:353",
           "format": "bytes",
           "label": null,
           "logBase": 1,
@@ -303,6 +391,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:354",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -335,7 +424,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 11
       },
       "hiddenSeries": false,
       "id": 9,
@@ -344,6 +433,7 @@
         "current": false,
         "max": false,
         "min": false,
+        "rightSide": true,
         "show": true,
         "total": false,
         "values": false
@@ -356,7 +446,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.4.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -378,7 +468,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Backup Size (Actual)",
+      "title": "Last Backup Size (Actual)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -394,6 +484,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:438",
           "format": "bytes",
           "label": null,
           "logBase": 1,
@@ -402,204 +493,7 @@
           "show": true
         },
         {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 16
-      },
-      "hiddenSeries": false,
-      "id": 5,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.4.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "ccp_backrest_last_full_backup_time_since_completion_seconds{stanza=\"[[backrest_stanza]]\"} + on(job,instance) group_left() (ccp_is_in_recovery_status == 2)",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{stanza}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Time Since Last Completed Backup (Full)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 16
-      },
-      "hiddenSeries": false,
-      "id": 6,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.4.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "ccp_backrest_last_diff_backup_time_since_completion_seconds{stanza=\"[[backrest_stanza]]\"} + on(job,instance) group_left() (ccp_is_in_recovery_status == 2)",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{stanza}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Time Since Last Completed Backup (Full,Diff)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
+          "$$hashKey": "object:439",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -623,7 +517,7 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "alpha",
           "value": "alpha"
         },
@@ -654,7 +548,7 @@
     ]
   },
   "time": {
-    "from": "now-14d",
+    "from": "now-2d",
     "to": "now"
   },
   "timepicker": {
@@ -673,5 +567,5 @@
   "timezone": "",
   "title": "pgBackRest",
   "uid": "QtHwNCrik",
-  "version": 1
+  "version": 3
 }

--- a/grafana/common/PGBouncer.json
+++ b/grafana/common/PGBouncer.json
@@ -565,15 +565,6 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
     "time_options": [
       "5m",
       "15m",

--- a/grafana/common/PG_Details.json
+++ b/grafana/common/PG_Details.json
@@ -1733,17 +1733,10 @@
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-2d",
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
     "time_options": [
       "5m",
       "15m",

--- a/grafana/common/PG_Details.json
+++ b/grafana/common/PG_Details.json
@@ -15,7 +15,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1618011856280,
+  "iteration": 1618856153917,
   "links": [],
   "panels": [
     {
@@ -686,7 +686,7 @@
       "links": [
         {
           "title": "TableSize Details",
-          "url": "/d/Igh7D7Hmz/tablesize-details"
+          "url": "/d/Igh7D7Hmz/tablesize-details?$__all_variables"
         }
       ],
       "nullPointMode": "null",
@@ -2135,8 +2135,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "alpha",
-          "value": "alpha"
+          "text": "crunchy",
+          "value": "crunchy"
         },
         "datasource": "PROMETHEUS",
         "definition": "label_values(up{exp_type='pg'}, cluster_name)",
@@ -2166,8 +2166,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "alpha_ip16_pg1",
-          "value": "alpha_ip16_pg1"
+          "text": "crunchy_pg1_crunchy",
+          "value": "crunchy_pg1_crunchy"
         },
         "datasource": "PROMETHEUS",
         "definition": "label_values(up{exp_type='pg', cluster_name=\"[[pgcluster]]\"}, job)",
@@ -2250,5 +2250,5 @@
   "timezone": "browser",
   "title": "PostgreSQL Details",
   "uid": "6jtN_vfiz",
-  "version": 8
+  "version": 2
 }

--- a/grafana/common/PG_Details.json
+++ b/grafana/common/PG_Details.json
@@ -71,7 +71,7 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "ccp_connection_stats_total{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"} / ccp_connection_stats_max_connections{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "expr": "ccp_connection_stats_total{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"} / ccp_connection_stats_max_connections{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -134,7 +134,7 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "1 - (ccp_connection_stats_idle{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"} / ccp_connection_stats_total{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"})",
+          "expr": "1 - (ccp_connection_stats_idle{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"} / ccp_connection_stats_total{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -200,7 +200,7 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "ccp_connection_stats_max_idle_in_txn_time{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "expr": "ccp_connection_stats_max_idle_in_txn_time{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -264,7 +264,7 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "ccp_transaction_wraparound_percent_towards_wraparound{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "expr": "ccp_transaction_wraparound_percent_towards_wraparound{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -328,7 +328,7 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "sum(ccp_stat_database_blks_hit{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"})  / sum( ccp_stat_database_blks_hit{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"} + ccp_stat_database_blks_read{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}) * 100",
+          "expr": "sum(ccp_stat_database_blks_hit{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"})  / sum( ccp_stat_database_blks_hit{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"} + ccp_stat_database_blks_read{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}) * 100",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -384,7 +384,7 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "ccp_replication_lag_size_bytes{cluster=\"[[pgcluster]]\", job=\"[[pgnodes]]\"}",
+          "expr": "ccp_replication_lag_size_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\"}",
           "interval": "",
           "legendFormat": "{{replica}}",
           "refId": "A"
@@ -446,7 +446,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ccp_connection_stats_max_connections{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "expr": "ccp_connection_stats_max_connections{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -456,7 +456,7 @@
           "step": 60
         },
         {
-          "expr": "ccp_connection_stats_active{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "expr": "ccp_connection_stats_active{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Active",
@@ -465,7 +465,7 @@
           "step": 60
         },
         {
-          "expr": "ccp_connection_stats_idle_in_txn{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "expr": "ccp_connection_stats_idle_in_txn{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "IdleTxn",
@@ -474,7 +474,7 @@
           "step": 60
         },
         {
-          "expr": "ccp_connection_stats_idle{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "expr": "ccp_connection_stats_idle{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Idle",
@@ -589,7 +589,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max by (cluster, job, replica) (ccp_replication_lag_size_bytes{cluster=\"[[pgcluster]]\", job=\"[[pgnodes]]\"})",
+          "expr": "max by (cluster, job, replica) (ccp_replication_lag_size_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\"})",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -598,7 +598,7 @@
           "refId": "A"
         },
         {
-          "expr": "ccp_replication_lag_replay_time{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "expr": "ccp_replication_lag_replay_time{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "Time {{job}}",
@@ -704,7 +704,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(ccp_database_size_bytes{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"})",
+          "expr": "sum(ccp_database_size_bytes{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -712,7 +712,7 @@
           "refId": "A"
         },
         {
-          "expr": "ccp_database_size_bytes{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}",
+          "expr": "ccp_database_size_bytes{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -815,7 +815,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(ccp_stat_database_xact_commit{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m])) + sum(irate(ccp_stat_database_xact_rollback{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
+          "expr": "sum(irate(ccp_stat_database_xact_commit{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m])) + sum(irate(ccp_stat_database_xact_rollback{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -823,7 +823,7 @@
           "refId": "A"
         },
         {
-          "expr": "irate(ccp_stat_database_xact_commit{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]) + irate(ccp_stat_database_xact_rollback{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m])",
+          "expr": "irate(ccp_stat_database_xact_commit{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]) + irate(ccp_stat_database_xact_rollback{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m])",
           "hide": false,
           "interval": "",
           "legendFormat": "{{ dbname }}",
@@ -923,7 +923,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ccp_transaction_wraparound_percent_towards_wraparound{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "expr": "ccp_transaction_wraparound_percent_towards_wraparound{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1023,7 +1023,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ccp_transaction_wraparound_percent_towards_emergency_autovac{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "expr": "ccp_transaction_wraparound_percent_towards_emergency_autovac{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1132,7 +1132,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(ccp_stat_database_tup_fetched{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
+          "expr": "sum(irate(ccp_stat_database_tup_fetched{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1142,7 +1142,7 @@
           "step": 240
         },
         {
-          "expr": "sum(irate(ccp_stat_database_tup_inserted{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
+          "expr": "sum(irate(ccp_stat_database_tup_inserted{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1152,7 +1152,7 @@
           "step": 240
         },
         {
-          "expr": "sum(irate(ccp_stat_database_tup_updated{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
+          "expr": "sum(irate(ccp_stat_database_tup_updated{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1162,7 +1162,7 @@
           "step": 240
         },
         {
-          "expr": "sum(irate(ccp_stat_database_tup_deleted{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
+          "expr": "sum(irate(ccp_stat_database_tup_deleted{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1172,7 +1172,7 @@
           "step": 240
         },
         {
-          "expr": "sum(irate(ccp_stat_database_tup_returned{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
+          "expr": "sum(irate(ccp_stat_database_tup_returned{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1276,7 +1276,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(ccp_locks_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"accessexclusivelock\", dbname=~\"[[pgdatabase]]\"})",
+          "expr": "sum(ccp_locks_count{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"accessexclusivelock\", dbname=~\"[[pgdatabase]]\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1285,7 +1285,7 @@
           "step": 240
         },
         {
-          "expr": "sum(ccp_locks_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"accesssharelock\", dbname=~\"[[pgdatabase]]\"})",
+          "expr": "sum(ccp_locks_count{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"accesssharelock\", dbname=~\"[[pgdatabase]]\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1294,7 +1294,7 @@
           "step": 240
         },
         {
-          "expr": "sum(ccp_locks_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"exclusivelock\", dbname=~\"[[pgdatabase]]\"})",
+          "expr": "sum(ccp_locks_count{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"exclusivelock\", dbname=~\"[[pgdatabase]]\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1303,7 +1303,7 @@
           "step": 240
         },
         {
-          "expr": "sum(ccp_locks_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"rowexclusivelock\", dbname=~\"[[pgdatabase]]\"})",
+          "expr": "sum(ccp_locks_count{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"rowexclusivelock\", dbname=~\"[[pgdatabase]]\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1312,7 +1312,7 @@
           "step": 240
         },
         {
-          "expr": "sum(ccp_locks_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"rowsharelock\", dbname=~\"[[pgdatabase]]\"})",
+          "expr": "sum(ccp_locks_count{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"rowsharelock\", dbname=~\"[[pgdatabase]]\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1321,7 +1321,7 @@
           "step": 240
         },
         {
-          "expr": "sum(ccp_locks_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"sharelock\", dbname=~\"[[pgdatabase]]\"})",
+          "expr": "sum(ccp_locks_count{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"sharelock\", dbname=~\"[[pgdatabase]]\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1330,7 +1330,7 @@
           "step": 240
         },
         {
-          "expr": "sum(ccp_locks_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"sharerowexclusivelock\", dbname=~\"[[pgdatabase]]\"})",
+          "expr": "sum(ccp_locks_count{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"sharerowexclusivelock\", dbname=~\"[[pgdatabase]]\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1339,7 +1339,7 @@
           "step": 240
         },
         {
-          "expr": "sum(ccp_locks_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"shareupdateexclusivelock\", dbname=~\"[[pgdatabase]]\"})",
+          "expr": "sum(ccp_locks_count{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"shareupdateexclusivelock\", dbname=~\"[[pgdatabase]]\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1441,7 +1441,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ccp_stat_database_blks_hit{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}  / ( ccp_stat_database_blks_hit{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"} + ccp_stat_database_blks_read{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}) * 100",
+          "expr": "ccp_stat_database_blks_hit{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}  / ( ccp_stat_database_blks_hit{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"} + ccp_stat_database_blks_read{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}) * 100",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1545,7 +1545,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(ccp_stat_database_xact_commit{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
+          "expr": "sum(irate(ccp_stat_database_xact_commit{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1555,7 +1555,7 @@
           "step": 120
         },
         {
-          "expr": "sum(irate(ccp_stat_database_xact_rollback{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
+          "expr": "sum(irate(ccp_stat_database_xact_rollback{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1669,7 +1669,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ccp_wal_activity_total_size_bytes{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "expr": "ccp_wal_activity_total_size_bytes{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1678,14 +1678,14 @@
           "refId": "A"
         },
         {
-          "expr": "idelta(ccp_archive_command_status_archived_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
+          "expr": "idelta(ccp_archive_command_status_archived_count{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
           "hide": false,
           "interval": "",
           "legendFormat": "Archive Rate",
           "refId": "B"
         },
         {
-          "expr": "idelta(ccp_archive_command_status_failed_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
+          "expr": "idelta(ccp_archive_command_status_failed_count{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
           "hide": false,
           "interval": "",
           "legendFormat": "Fail Rate",
@@ -1787,7 +1787,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(ccp_stat_bgwriter_buffers_alloc{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
+          "expr": "irate(ccp_stat_bgwriter_buffers_alloc{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1797,7 +1797,7 @@
           "step": 120
         },
         {
-          "expr": "irate(ccp_stat_bgwriter_buffers_backend{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
+          "expr": "irate(ccp_stat_bgwriter_buffers_backend{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1807,7 +1807,7 @@
           "step": 120
         },
         {
-          "expr": "irate(ccp_stat_bgwriter_buffers_backend_fsync{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
+          "expr": "irate(ccp_stat_bgwriter_buffers_backend_fsync{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1817,7 +1817,7 @@
           "step": 120
         },
         {
-          "expr": "irate(ccp_stat_bgwriter_buffers_checkpoint{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
+          "expr": "irate(ccp_stat_bgwriter_buffers_checkpoint{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1827,7 +1827,7 @@
           "step": 120
         },
         {
-          "expr": "irate(ccp_stat_bgwriter_buffers_clean{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
+          "expr": "irate(ccp_stat_bgwriter_buffers_clean{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1931,7 +1931,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(ccp_stat_database_deadlocks{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
+          "expr": "sum(rate(ccp_stat_database_deadlocks{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1941,7 +1941,7 @@
           "step": 240
         },
         {
-          "expr": "sum(rate(ccp_stat_database_conflicts{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
+          "expr": "sum(rate(ccp_stat_database_conflicts{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -2045,7 +2045,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(ccp_stat_user_tables_autovacuum_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
+          "expr": "sum(rate(ccp_stat_user_tables_autovacuum_count{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -2064,7 +2064,7 @@
           "step": 120
         },
         {
-          "expr": "sum(rate(ccp_stat_user_tables_vacuum_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m]))",
+          "expr": "sum(rate(ccp_stat_user_tables_vacuum_count{cluster_name=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -2170,7 +2170,7 @@
           "value": "alpha_ip16_pg1"
         },
         "datasource": "PROMETHEUS",
-        "definition": "label_values(up{exp_type='pg', cluster=\"[[pgcluster]]\"}, job)",
+        "definition": "label_values(up{exp_type='pg', cluster_name=\"[[pgcluster]]\"}, job)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2180,7 +2180,7 @@
         "name": "pgnodes",
         "options": [],
         "query": {
-          "query": "label_values(up{exp_type='pg', cluster=\"[[pgcluster]]\"}, job)",
+          "query": "label_values(up{exp_type='pg', cluster_name=\"[[pgcluster]]\"}, job)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -2205,7 +2205,7 @@
           ]
         },
         "datasource": "PROMETHEUS",
-        "definition": "label_values(ccp_database_size_bytes{cluster=\"[[pgcluster]]\", job=\"[[pgnodes]]\"}, dbname)",
+        "definition": "label_values(ccp_database_size_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\"}, dbname)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2215,7 +2215,7 @@
         "name": "pgdatabase",
         "options": [],
         "query": {
-          "query": "label_values(ccp_database_size_bytes{cluster=\"[[pgcluster]]\", job=\"[[pgnodes]]\"}, dbname)",
+          "query": "label_values(ccp_database_size_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\"}, dbname)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/grafana/common/PG_Details.json
+++ b/grafana/common/PG_Details.json
@@ -15,10 +15,198 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 8,
-  "iteration": 1614123620619,
+  "iteration": 1617927488793,
   "links": [],
   "panels": [
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "hideTimeOverride": true,
+      "id": 51,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "7.4.5",
+      "targets": [
+        {
+          "expr": "(ccp_connection_stats_total{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"} / ccp_connection_stats_max_connections{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"})",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": "5m",
+      "title": "Total Connections",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "hideTimeOverride": true,
+      "id": 53,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "7.4.5",
+      "targets": [
+        {
+          "expr": "(ccp_connection_stats_active{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"} / ccp_connection_stats_max_connections{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"})",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": "5m",
+      "title": "Active Connections",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 300
+              },
+              {
+                "color": "red",
+                "value": 900
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "hideTimeOverride": true,
+      "id": 52,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "7.4.5",
+      "targets": [
+        {
+          "expr": "ccp_connection_stats_max_idle_in_txn_time{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": "5m",
+      "title": "Idle In Txn Time",
+      "type": "gauge"
+    },
     {
       "aliasColors": {},
       "bars": false,
@@ -36,8 +224,8 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 6,
-        "w": 24,
-        "x": 0,
+        "w": 12,
+        "x": 12,
         "y": 0
       },
       "hiddenSeries": false,
@@ -61,7 +249,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -71,8 +259,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ccp_connection_stats_max_connections{job=~\"[[pgnodes]]\"}",
+          "expr": "ccp_connection_stats_max_connections{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
           "hide": false,
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Max",
           "metric": "",
@@ -80,7 +269,8 @@
           "step": 60
         },
         {
-          "expr": "ccp_connection_stats_active{job=~\"[[pgnodes]]\"}",
+          "expr": "ccp_connection_stats_active{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Active",
           "metric": "",
@@ -88,7 +278,7 @@
           "step": 60
         },
         {
-          "expr": "ccp_connection_stats_idle_in_txn{job=~\"[[pgnodes]]\"}",
+          "expr": "ccp_connection_stats_idle_in_txn{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "IdleTrn",
@@ -97,7 +287,8 @@
           "step": 60
         },
         {
-          "expr": "ccp_connection_stats_idle{job=~\"[[pgnodes]]\"}",
+          "expr": "ccp_connection_stats_idle{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Idle",
           "metric": "",
@@ -127,6 +318,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:647",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -135,6 +327,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:648",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -164,7 +357,7 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 9,
+        "h": 8,
         "w": 12,
         "x": 0,
         "y": 6
@@ -193,7 +386,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -203,15 +396,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(ccp_database_size_bytes{job=~\"[[pgnodes]]\"})",
+          "expr": "sum(ccp_database_size_bytes{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "total size",
           "refId": "A"
         },
         {
-          "expr": "ccp_database_size_bytes{job=~\"[[pgnodes]]\"}",
+          "expr": "ccp_database_size_bytes{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{dbname}}",
           "refId": "B"
@@ -221,7 +416,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Database Size",
+      "title": "Database Size - [[pgdatabase]]",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -237,6 +432,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:399",
           "format": "bytes",
           "label": null,
           "logBase": 1,
@@ -245,6 +441,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:400",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -274,7 +471,7 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 9,
+        "h": 8,
         "w": 12,
         "x": 12,
         "y": 6
@@ -286,7 +483,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -298,7 +495,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -308,18 +505,26 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(ccp_stat_database_xact_commit{job=~\"[[pgnodes]]\"}[1m])) + sum(irate(ccp_stat_database_xact_rollback{job=~\"[[pgnodes]]\"}[1m]))",
+          "expr": "sum(irate(ccp_stat_database_xact_commit{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[1m])) + sum(irate(ccp_stat_database_xact_rollback{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[1m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "",
+          "legendFormat": "total",
           "refId": "A"
+        },
+        {
+          "expr": "irate(ccp_stat_database_xact_commit{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[1m]) + irate(ccp_stat_database_xact_rollback{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[1m])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{ dbname }}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Transactions Per Minute (TPM)",
+      "title": "Transactions Per Second (TPS) - [[pgdatabase]]",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -335,6 +540,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:229",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -343,6 +549,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:230",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -373,18 +580,22 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 6,
+        "h": 7,
         "w": 12,
         "x": 0,
-        "y": 15
+        "y": 14
       },
       "hiddenSeries": false,
       "id": 35,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
+        "hideEmpty": true,
+        "hideZero": false,
         "max": false,
         "min": false,
+        "rightSide": true,
         "show": true,
         "total": false,
         "values": false
@@ -397,29 +608,43 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:675",
+          "alias": "/Time/",
+          "yaxis": 2
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ccp_replication_lag_size_bytes{job=~\"[[pgnodes]]\"}",
+          "expr": "max by (cluster, job, replica) (ccp_replication_lag_size_bytes{cluster=\"[[pgcluster]]\", job=\"[[pgnodes]]\"})",
           "format": "time_series",
           "instant": false,
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{replica_hostname}} ({{replica}}:{{replica_port}})",
+          "legendFormat": "Bytes {{job}}",
           "refId": "A"
+        },
+        {
+          "expr": "ccp_replication_lag_replay_time{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Time {{job}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Replication Byte Lag (Primary Only)",
+      "title": "Replication Lag",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -435,19 +660,21 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:153",
           "format": "bytes",
-          "label": null,
+          "label": "Lag Bytes",
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
-          "format": "short",
-          "label": null,
+          "$$hashKey": "object:154",
+          "format": "dtdhms",
+          "label": "Lag Time (hh:mm:ss)",
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         }
       ],
@@ -462,6 +689,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "PROMETHEUS",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -472,208 +700,10 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 6,
+        "h": 7,
         "w": 12,
         "x": 12,
-        "y": 15
-      },
-      "hiddenSeries": false,
-      "id": 37,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.4.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "ccp_replication_lag_replay_time{job=~\"[[pgnodes]]\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Replication Lag Time (Replica Only)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "PROMETHEUS",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 0,
-        "y": 21
-      },
-      "hiddenSeries": false,
-      "id": 12,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.4.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "ccp_stat_database_blks_hit{ job=~\"[[pgnodes]]\"}  / ( ccp_stat_database_blks_hit{job=~\"[[pgnodes]]\"} + ccp_stat_database_blks_read{ job=~\"[[pgnodes]]\"} ) * 100",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{dbname}}",
-          "metric": "pg_stat_database_",
-          "refId": "A",
-          "step": 120
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Cache Hit Ratio",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "percent",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "PROMETHEUS",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 12,
-        "y": 21
+        "y": 14
       },
       "hiddenSeries": false,
       "id": 13,
@@ -694,7 +724,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -704,19 +734,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(ccp_stat_database_xact_commit{job=~\"[[pgnodes]]\"}[5m]))",
+          "expr": "sum(irate(ccp_stat_database_xact_commit{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "Commit",
+          "legendFormat": "commit",
           "metric": "pg_stat_database_xact_commit",
           "refId": "A",
           "step": 120
         },
         {
-          "expr": "sum(irate(ccp_stat_database_xact_rollback{job=~\"[[pgnodes]]\"}[5m]))",
+          "expr": "sum(irate(ccp_stat_database_xact_rollback{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "Rollback",
+          "legendFormat": "rollback",
           "refId": "B",
           "step": 120
         }
@@ -725,7 +757,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Commit vs Rollback",
+      "title": "Commit vs Rollback - [[pgdatabase]]",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -741,6 +773,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:961",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -749,6 +782,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:962",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -777,6 +811,207 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 21
+      },
+      "hiddenSeries": false,
+      "id": 47,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.4.5",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "ccp_transaction_wraparound_percent_towards_wraparound{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "% toward wraparound",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1131",
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1132",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 21
+      },
+      "hiddenSeries": false,
+      "id": 45,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.4.5",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "ccp_transaction_wraparound_percent_towards_emergency_autovac{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "% towards emergency vacuum",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1207",
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1208",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "PROMETHEUS",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
         "h": 10,
         "w": 12,
         "x": 0,
@@ -787,10 +1022,10 @@
       "legend": {
         "alignAsTable": true,
         "avg": true,
-        "current": true,
+        "current": false,
         "max": true,
         "min": true,
-        "rightSide": false,
+        "rightSide": true,
         "show": true,
         "total": false,
         "values": true
@@ -809,7 +1044,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -819,8 +1054,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(ccp_stat_database_tup_fetched{job=~\"[[pgnodes]]\"}[5m]))",
+          "expr": "sum(irate(ccp_stat_database_tup_fetched{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Fetched",
           "metric": "pg_stat_database_tup_fetched",
@@ -828,8 +1064,9 @@
           "step": 240
         },
         {
-          "expr": "sum(irate(ccp_stat_database_tup_inserted{job=~\"[[pgnodes]]\"}[5m]))",
+          "expr": "sum(irate(ccp_stat_database_tup_inserted{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Inserted",
           "metric": "pg_stat_database_tup_inserted",
@@ -837,8 +1074,9 @@
           "step": 240
         },
         {
-          "expr": "sum(irate(ccp_stat_database_tup_updated{job=~\"[[pgnodes]]\"}[5m]))",
+          "expr": "sum(irate(ccp_stat_database_tup_updated{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Updated",
           "metric": "pg_stat_database_tup_updated",
@@ -846,8 +1084,9 @@
           "step": 240
         },
         {
-          "expr": "sum(irate(ccp_stat_database_tup_deleted{job=~\"[[pgnodes]]\"}[5m]))",
+          "expr": "sum(irate(ccp_stat_database_tup_deleted{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Deleted",
           "metric": "pg_stat_database_tup_deleted",
@@ -855,8 +1094,9 @@
           "step": 240
         },
         {
-          "expr": "sum(irate(ccp_stat_database_tup_returned{job=~\"[[pgnodes]]\"}[5m]))",
+          "expr": "sum(irate(ccp_stat_database_tup_returned{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Returned",
           "metric": "pg_stat_database_tup_returned",
@@ -868,7 +1108,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "CRUD",
+      "title": "CRUD - [[pgdatabase]]",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -884,6 +1124,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:1053",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -892,6 +1133,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:1054",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -933,7 +1175,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "rightSide": false,
+        "rightSide": true,
         "show": true,
         "total": false,
         "values": true
@@ -946,7 +1188,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -956,64 +1198,72 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(ccp_locks_count{job=~\"[[pgnodes]]\",mode=\"accessexclusivelock\"})",
+          "expr": "sum(ccp_locks_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"accessexclusivelock\", dbname=~\"[[pgdatabase]]\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "accessexclusive",
           "refId": "A",
           "step": 240
         },
         {
-          "expr": "sum(ccp_locks_count{job=~\"[[pgnodes]]\",mode=\"accesssharelock\"})",
+          "expr": "sum(ccp_locks_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"accesssharelock\", dbname=~\"[[pgdatabase]]\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "accessshare",
           "refId": "B",
           "step": 240
         },
         {
-          "expr": "sum(ccp_locks_count{job=~\"[[pgnodes]]\",mode=\"exclusivelock\"})",
+          "expr": "sum(ccp_locks_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"exclusivelock\", dbname=~\"[[pgdatabase]]\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "exclusive",
           "refId": "C",
           "step": 240
         },
         {
-          "expr": "sum(ccp_locks_count{job=~\"[[pgnodes]]\",mode=\"rowexclusivelock\"})",
+          "expr": "sum(ccp_locks_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"rowexclusivelock\", dbname=~\"[[pgdatabase]]\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "rowexclusive",
           "refId": "D",
           "step": 240
         },
         {
-          "expr": "sum(ccp_locks_count{job=~\"[[pgnodes]]\",mode=\"rowsharelock\"})",
+          "expr": "sum(ccp_locks_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"rowsharelock\", dbname=~\"[[pgdatabase]]\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "rowshare",
           "refId": "E",
           "step": 240
         },
         {
-          "expr": "sum(ccp_locks_count{job=~\"[[pgnodes]]\",mode=\"sharelock\"})",
+          "expr": "sum(ccp_locks_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"sharelock\", dbname=~\"[[pgdatabase]]\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "share",
           "refId": "F",
           "step": 240
         },
         {
-          "expr": "sum(ccp_locks_count{job=~\"[[pgnodes]]\",mode=\"sharerowexclusivelock\"})",
+          "expr": "sum(ccp_locks_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"sharerowexclusivelock\", dbname=~\"[[pgdatabase]]\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "sharerowexclusive",
           "refId": "G",
           "step": 240
         },
         {
-          "expr": "sum(ccp_locks_count{job=~\"[[pgnodes]]\",mode=\"shareupdateexclusivelock\"})",
+          "expr": "sum(ccp_locks_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\",mode=\"shareupdateexclusivelock\", dbname=~\"[[pgdatabase]]\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "shareupdateexclusive",
           "refId": "H",
@@ -1024,7 +1274,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Locks",
+      "title": "Locks - [[pgdatabase]]",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1040,6 +1290,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:1795",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1048,6 +1299,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:1796",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1069,35 +1321,39 @@
       "datasource": "PROMETHEUS",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 0,
         "y": 37
       },
-      "id": 15,
+      "hiddenSeries": false,
+      "id": 12,
       "legend": {
-        "alignAsTable": false,
         "avg": false,
-        "current": true,
+        "current": false,
         "max": false,
         "min": false,
-        "rightSide": false,
         "show": true,
         "total": false,
-        "values": true
+        "values": false
       },
       "lines": true,
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1107,29 +1363,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(ccp_stat_database_deadlocks{job=~\"[[pgnodes]]\"}[5m]))",
+          "expr": "ccp_stat_database_blks_hit{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}  / ( ccp_stat_database_blks_hit{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"} + ccp_stat_database_blks_read{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}) * 100",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "Conflicts",
-          "metric": "pg_stat_database_conflicts",
+          "legendFormat": "{{dbname}}",
+          "metric": "pg_stat_database_",
           "refId": "A",
-          "step": 240
-        },
-        {
-          "expr": "sum(rate(ccp_stat_database_conflicts{job=~\"[[pgnodes]]\"}[5m]))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "DeadLocks",
-          "metric": "pg_stat_database_deadlocks",
-          "refId": "B",
-          "step": 240
+          "step": 120
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Conflicts/DeadLocks",
+      "title": "Cache Hit Ratio - [[pgdatabase]]",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1145,7 +1393,8 @@
       },
       "yaxes": [
         {
-          "format": "short",
+          "$$hashKey": "object:885",
+          "format": "percent",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -1153,6 +1402,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:886",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1179,12 +1429,14 @@
         "overrides": []
       },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 12,
         "y": 37
       },
+      "hiddenSeries": false,
       "id": 14,
       "legend": {
         "alignAsTable": true,
@@ -1192,7 +1444,7 @@
         "current": false,
         "max": true,
         "min": true,
-        "rightSide": false,
+        "rightSide": true,
         "show": true,
         "sortDesc": true,
         "total": false,
@@ -1202,8 +1454,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1213,8 +1468,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(ccp_stat_bgwriter_buffers_alloc{job=~\"[[pgnodes]]\"}[5m])",
+          "expr": "irate(ccp_stat_bgwriter_buffers_alloc{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Allocated",
           "metric": "pg_stat_bgwriter_buffers_alloc",
@@ -1222,8 +1478,9 @@
           "step": 120
         },
         {
-          "expr": "irate(ccp_stat_bgwriter_buffers_backend{job=~\"[[pgnodes]]\"}[5m])",
+          "expr": "irate(ccp_stat_bgwriter_buffers_backend{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Backend",
           "metric": "pg_stat_bgwriter_buffers_backend",
@@ -1231,8 +1488,9 @@
           "step": 120
         },
         {
-          "expr": "irate(ccp_stat_bgwriter_buffers_backend_fsync{job=~\"[[pgnodes]]\"}[5m])",
+          "expr": "irate(ccp_stat_bgwriter_buffers_backend_fsync{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "FSync",
           "metric": "pg_stat_bgwriter_buffers_backend_fsync",
@@ -1240,8 +1498,9 @@
           "step": 120
         },
         {
-          "expr": "irate(ccp_stat_bgwriter_buffers_checkpoint{job=~\"[[pgnodes]]\"}[5m])",
+          "expr": "irate(ccp_stat_bgwriter_buffers_checkpoint{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "CheckPoint",
           "metric": "pg_stat_bgwriter_buffers_checkpoint",
@@ -1249,8 +1508,9 @@
           "step": 120
         },
         {
-          "expr": "irate(ccp_stat_bgwriter_buffers_clean{job=~\"[[pgnodes]]\"}[5m])",
+          "expr": "irate(ccp_stat_bgwriter_buffers_clean{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Clean",
           "metric": "pg_stat_bgwriter_buffers_clean",
@@ -1278,6 +1538,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:2175",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1286,6 +1547,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:2176",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1312,194 +1574,14 @@
         "overrides": []
       },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 0,
         "y": 44
       },
-      "id": 47,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pluginVersion": "7.4.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "ccp_transaction_wraparound_percent_towards_wraparound{job=~\"[[pgnodes]]\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "% toward wraparound",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "percent",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "PROMETHEUS",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 44
-      },
-      "id": 45,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pluginVersion": "7.4.2",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "ccp_transaction_wraparound_percent_towards_emergency_autovac{job=~\"[[pgnodes]]\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "% towards emergency vacuum",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "percent",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "PROMETHEUS",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 51
-      },
+      "hiddenSeries": false,
       "id": 49,
       "legend": {
         "avg": false,
@@ -1514,8 +1596,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1525,9 +1610,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ccp_wal_activity_total_size_bytes{job=~\"[[pgnodes]]\"}",
+          "expr": "ccp_wal_activity_total_size_bytes{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
+          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -1551,6 +1638,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:1283",
           "format": "bytes",
           "label": null,
           "logBase": 1,
@@ -1559,6 +1647,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:1284",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1585,12 +1674,14 @@
         "overrides": []
       },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 51
+        "y": 44
       },
+      "hiddenSeries": false,
       "id": 16,
       "legend": {
         "alignAsTable": true,
@@ -1598,7 +1689,7 @@
         "current": false,
         "max": true,
         "min": true,
-        "rightSide": false,
+        "rightSide": true,
         "show": true,
         "total": false,
         "values": true
@@ -1607,8 +1698,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.4.2",
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1618,8 +1712,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(ccp_stat_user_tables_autovacuum_count{job=~\"[[pgnodes]]\"}[5m]))",
+          "expr": "sum(rate(ccp_stat_user_tables_autovacuum_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "AutoVacuum",
           "metric": "ccp_stat_user_tables_autovacuum_count",
@@ -1627,16 +1722,18 @@
           "step": 120
         },
         {
-          "expr": "sum(rate(ccp_stat_user_tables_autoanalyze_count{job=~\"[[pgnodes]]\"}[5m]))",
+          "expr": "sum(rate(ccp_stat_user_tables_autoanalyze_count{job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "AutoAnalyze",
           "refId": "B",
           "step": 120
         },
         {
-          "expr": "sum(rate(ccp_stat_user_tables_vacuum_count{job=~\"[[pgnodes]]\"}[5m]))",
+          "expr": "sum(rate(ccp_stat_user_tables_vacuum_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Vacuum",
           "refId": "C",
@@ -1655,7 +1752,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Vacuum/Analyze Activity Rate",
+      "title": "Vacuum/Analyze Activity Rate - [[pgdatabase]]",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1671,6 +1768,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:2327",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1679,6 +1777,121 @@
           "show": true
         },
         {
+          "$$hashKey": "object:2328",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 51
+      },
+      "hiddenSeries": false,
+      "id": 15,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.4.5",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(ccp_stat_database_deadlocks{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Conflicts",
+          "metric": "pg_stat_database_conflicts",
+          "refId": "A",
+          "step": 240
+        },
+        {
+          "expr": "sum(rate(ccp_stat_database_conflicts{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "DeadLocks",
+          "metric": "pg_stat_database_deadlocks",
+          "refId": "B",
+          "step": 240
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Conflicts/DeadLocks - [[pgdatabase]]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:2099",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:2100",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1702,23 +1915,90 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
-          "text": "pg1_alpha",
-          "value": "pg1_alpha"
+          "selected": true,
+          "text": "alpha",
+          "value": "alpha"
         },
         "datasource": "PROMETHEUS",
-        "definition": "",
+        "definition": "label_values(up{exp_type='pg'}, cluster)",
         "description": null,
         "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "PGCluster",
         "multi": false,
+        "name": "pgcluster",
+        "options": [],
+        "query": {
+          "query": "label_values(up{exp_type='pg'}, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "alpha_ip16_pg1",
+          "value": "alpha_ip16_pg1"
+        },
+        "datasource": "PROMETHEUS",
+        "definition": "label_values(up{exp_type='pg', cluster=\"[[pgcluster]]\"}, job)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Node",
+        "multi": false,
         "name": "pgnodes",
         "options": [],
         "query": {
-          "query": "label_values(up{exp_type='pg'}, job)",
-          "refId": "PROMETHEUS-pgnodes-Variable-Query"
+          "query": "label_values(up{exp_type='pg', cluster=\"[[pgcluster]]\"}, job)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "tags": [],
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "PROMETHEUS",
+        "definition": "label_values(ccp_database_size_bytes{cluster=\"[[pgcluster]]\", job=\"[[pgnodes]]\"}, dbname)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "PGDatabase",
+        "multi": true,
+        "name": "pgdatabase",
+        "options": [],
+        "query": {
+          "query": "label_values(ccp_database_size_bytes{cluster=\"[[pgcluster]]\", job=\"[[pgnodes]]\"}, dbname)",
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -1752,5 +2032,5 @@
   "timezone": "browser",
   "title": "PostgreSQL Details",
   "uid": "6jtN_vfiz",
-  "version": 1
+  "version": 5
 }

--- a/grafana/common/PG_Details.json
+++ b/grafana/common/PG_Details.json
@@ -15,7 +15,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1617927488793,
+  "iteration": 1618011856280,
   "links": [],
   "panels": [
     {
@@ -71,14 +71,14 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "(ccp_connection_stats_total{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"} / ccp_connection_stats_max_connections{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"})",
+          "expr": "ccp_connection_stats_total{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"} / ccp_connection_stats_max_connections{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         }
       ],
       "timeFrom": "5m",
-      "title": "Total Connections",
+      "title": "Connections - Total % Max",
       "type": "gauge"
     },
     {
@@ -99,11 +99,11 @@
               },
               {
                 "color": "orange",
-                "value": 75
+                "value": 95
               },
               {
                 "color": "red",
-                "value": 90
+                "value": 98
               }
             ]
           },
@@ -118,7 +118,7 @@
         "y": 0
       },
       "hideTimeOverride": true,
-      "id": 53,
+      "id": 54,
       "options": {
         "reduceOptions": {
           "calcs": [
@@ -128,20 +128,20 @@
           "values": false
         },
         "showThresholdLabels": false,
-        "showThresholdMarkers": true,
+        "showThresholdMarkers": false,
         "text": {}
       },
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "(ccp_connection_stats_active{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"} / ccp_connection_stats_max_connections{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"})",
+          "expr": "1 - (ccp_connection_stats_idle{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"} / ccp_connection_stats_total{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         }
       ],
       "timeFrom": "5m",
-      "title": "Active Connections",
+      "title": "Active % of Open Conn",
       "type": "gauge"
     },
     {
@@ -183,6 +183,73 @@
       "hideTimeOverride": true,
       "id": 52,
       "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.5",
+      "targets": [
+        {
+          "expr": "ccp_connection_stats_max_idle_in_txn_time{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": "5m",
+      "title": "Idle In Txn Time",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 75
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "hideTimeOverride": true,
+      "id": 56,
+      "options": {
+        "orientation": "auto",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -197,15 +264,135 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "ccp_connection_stats_max_idle_in_txn_time{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "expr": "ccp_transaction_wraparound_percent_towards_wraparound{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         }
       ],
       "timeFrom": "5m",
-      "title": "Idle In Txn Time",
+      "title": "% Toward Wraparound",
       "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 75
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "hideTimeOverride": true,
+      "id": 57,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "7.4.5",
+      "targets": [
+        {
+          "expr": "sum(ccp_stat_database_blks_hit{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"})  / sum( ccp_stat_database_blks_hit{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"} + ccp_stat_database_blks_read{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}) * 100",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": "5m",
+      "title": "Cache Hit Ratio",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "hideTimeOverride": true,
+      "id": 55,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "text": {}
+      },
+      "pluginVersion": "7.4.5",
+      "targets": [
+        {
+          "expr": "ccp_replication_lag_size_bytes{cluster=\"[[pgcluster]]\", job=\"[[pgnodes]]\"}",
+          "interval": "",
+          "legendFormat": "{{replica}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": "5m",
+      "title": "Streaming Byte Lag",
+      "type": "bargauge"
     },
     {
       "aliasColors": {},
@@ -225,13 +412,13 @@
       "gridPos": {
         "h": 6,
         "w": 12,
-        "x": 12,
-        "y": 0
+        "x": 0,
+        "y": 6
       },
       "hiddenSeries": false,
       "id": 18,
       "legend": {
-        "alignAsTable": true,
+        "alignAsTable": false,
         "avg": false,
         "current": false,
         "max": false,
@@ -246,7 +433,7 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "alertThreshold": false
       },
       "percentage": false,
       "pluginVersion": "7.4.5",
@@ -281,7 +468,7 @@
           "expr": "ccp_connection_stats_idle_in_txn{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "IdleTrn",
+          "legendFormat": "IdleTxn",
           "metric": "",
           "refId": "C",
           "step": 60
@@ -302,7 +489,7 @@
       "timeShift": null,
       "title": "Connections",
       "tooltip": {
-        "shared": false,
+        "shared": true,
         "sort": 0,
         "value_type": "individual"
       },
@@ -347,6 +534,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "PROMETHEUS",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -357,10 +545,129 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "hiddenSeries": false,
+      "id": 35,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.4.5",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:675",
+          "alias": "/Time/",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max by (cluster, job, replica) (ccp_replication_lag_size_bytes{cluster=\"[[pgcluster]]\", job=\"[[pgnodes]]\"})",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Bytes {{replica}}",
+          "refId": "A"
+        },
+        {
+          "expr": "ccp_replication_lag_replay_time{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Time {{job}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Replication Lag",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:153",
+          "format": "bytes",
+          "label": "Lag Bytes",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:154",
+          "format": "dtdhms",
+          "label": "Lag Time (hh:mm:ss)",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
         "w": 12,
         "x": 0,
-        "y": 6
+        "y": 12
       },
       "hiddenSeries": false,
       "id": 39,
@@ -369,6 +676,7 @@
         "current": false,
         "max": false,
         "min": false,
+        "rightSide": true,
         "show": true,
         "total": false,
         "values": false
@@ -471,18 +779,20 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 12,
         "x": 12,
-        "y": 6
+        "y": 12
       },
       "hiddenSeries": false,
       "id": 41,
       "legend": {
+        "alignAsTable": false,
         "avg": false,
         "current": false,
         "max": false,
         "min": false,
+        "rightSide": true,
         "show": true,
         "total": false,
         "values": false
@@ -492,7 +802,7 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "alertThreshold": false
       },
       "percentage": false,
       "pluginVersion": "7.4.5",
@@ -505,7 +815,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(ccp_stat_database_xact_commit{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[1m])) + sum(irate(ccp_stat_database_xact_rollback{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[1m]))",
+          "expr": "sum(irate(ccp_stat_database_xact_commit{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m])) + sum(irate(ccp_stat_database_xact_rollback{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -513,7 +823,7 @@
           "refId": "A"
         },
         {
-          "expr": "irate(ccp_stat_database_xact_commit{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[1m]) + irate(ccp_stat_database_xact_rollback{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[1m])",
+          "expr": "irate(ccp_stat_database_xact_commit{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]) + irate(ccp_stat_database_xact_rollback{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m])",
           "hide": false,
           "interval": "",
           "legendFormat": "{{ dbname }}",
@@ -569,239 +879,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "PROMETHEUS",
-      "description": "Note that replica_port can change if replicas ever detach and re-attach",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 14
-      },
-      "hiddenSeries": false,
-      "id": 35,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": false,
-        "hideEmpty": true,
-        "hideZero": false,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.4.5",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:675",
-          "alias": "/Time/",
-          "yaxis": 2
-        }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "max by (cluster, job, replica) (ccp_replication_lag_size_bytes{cluster=\"[[pgcluster]]\", job=\"[[pgnodes]]\"})",
-          "format": "time_series",
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Bytes {{job}}",
-          "refId": "A"
-        },
-        {
-          "expr": "ccp_replication_lag_replay_time{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "Time {{job}}",
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Replication Lag",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:153",
-          "format": "bytes",
-          "label": "Lag Bytes",
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "$$hashKey": "object:154",
-          "format": "dtdhms",
-          "label": "Lag Time (hh:mm:ss)",
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "PROMETHEUS",
       "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 14
-      },
-      "hiddenSeries": false,
-      "id": 13,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.4.5",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(irate(ccp_stat_database_xact_commit{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "commit",
-          "metric": "pg_stat_database_xact_commit",
-          "refId": "A",
-          "step": 120
-        },
-        {
-          "expr": "sum(irate(ccp_stat_database_xact_rollback{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "rollback",
-          "refId": "B",
-          "step": 120
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Commit vs Rollback - [[pgdatabase]]",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:961",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:962",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "PROMETHEUS",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -814,7 +892,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 21
+        "y": 19
       },
       "hiddenSeries": false,
       "id": 47,
@@ -857,7 +935,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "% toward wraparound",
+      "title": "% Toward Wraparound",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -914,7 +992,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 21
+        "y": 19
       },
       "hiddenSeries": false,
       "id": 45,
@@ -957,7 +1035,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "% towards emergency vacuum",
+      "title": "% Towards Emergency Vacuum",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1015,7 +1093,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 27
+        "y": 25
       },
       "hiddenSeries": false,
       "id": 11,
@@ -1165,7 +1243,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 27
+        "y": 25
       },
       "hiddenSeries": false,
       "id": 17,
@@ -1332,7 +1410,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 37
+        "y": 35
       },
       "hiddenSeries": false,
       "id": 12,
@@ -1422,6 +1500,247 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "PROMETHEUS",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "hiddenSeries": false,
+      "id": 13,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.4.5",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(ccp_stat_database_xact_commit{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "commit",
+          "metric": "pg_stat_database_xact_commit",
+          "refId": "A",
+          "step": 120
+        },
+        {
+          "expr": "sum(irate(ccp_stat_database_xact_rollback{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "rollback",
+          "refId": "B",
+          "step": 120
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Commit vs Rollback - [[pgdatabase]]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:961",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:962",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "hiddenSeries": false,
+      "id": 49,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.4.5",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:852",
+          "alias": "/Archive*/",
+          "yaxis": 2
+        },
+        {
+          "$$hashKey": "object:859",
+          "alias": "/Fail*/",
+          "color": "#C4162A",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "ccp_wal_activity_total_size_bytes{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Total Size",
+          "refId": "A"
+        },
+        {
+          "expr": "idelta(ccp_archive_command_status_archived_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Archive Rate",
+          "refId": "B"
+        },
+        {
+          "expr": "idelta(ccp_archive_command_status_failed_count{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}[5m])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Fail Rate",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "WAL Activity",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1283",
+          "format": "bytes",
+          "label": "Total Size",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1284",
+          "format": "short",
+          "label": "Rate (5m)",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "PROMETHEUS",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -1434,7 +1753,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 37
+        "y": 42
       },
       "hiddenSeries": false,
       "id": 14,
@@ -1579,16 +1898,18 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 44
+        "y": 49
       },
       "hiddenSeries": false,
-      "id": 49,
+      "id": 15,
       "legend": {
+        "alignAsTable": false,
         "avg": false,
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "rightSide": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -1610,19 +1931,31 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ccp_wal_activity_total_size_bytes{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\"}",
+          "expr": "sum(rate(ccp_stat_database_deadlocks{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
           "format": "time_series",
           "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "refId": "A"
+          "intervalFactor": 2,
+          "legendFormat": "Conflicts",
+          "metric": "pg_stat_database_conflicts",
+          "refId": "A",
+          "step": 240
+        },
+        {
+          "expr": "sum(rate(ccp_stat_database_conflicts{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "DeadLocks",
+          "metric": "pg_stat_database_deadlocks",
+          "refId": "B",
+          "step": 240
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Total WAL Size",
+      "title": "Conflicts/DeadLocks - [[pgdatabase]]",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1638,8 +1971,8 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:1283",
-          "format": "bytes",
+          "$$hashKey": "object:2099",
+          "format": "short",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -1647,7 +1980,7 @@
           "show": true
         },
         {
-          "$$hashKey": "object:1284",
+          "$$hashKey": "object:2100",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1679,7 +2012,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 44
+        "y": 49
       },
       "hiddenSeries": false,
       "id": 16,
@@ -1790,120 +2123,6 @@
         "align": false,
         "alignLevel": null
       }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "PROMETHEUS",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 51
-      },
-      "hiddenSeries": false,
-      "id": 15,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.4.5",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(rate(ccp_stat_database_deadlocks{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "Conflicts",
-          "metric": "pg_stat_database_conflicts",
-          "refId": "A",
-          "step": 240
-        },
-        {
-          "expr": "sum(rate(ccp_stat_database_conflicts{cluster=\"[[pgcluster]]\", job=~\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\"}[5m]))",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "DeadLocks",
-          "metric": "pg_stat_database_deadlocks",
-          "refId": "B",
-          "step": 240
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Conflicts/DeadLocks - [[pgdatabase]]",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:2099",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:2100",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
     }
   ],
   "refresh": "15m",
@@ -1915,7 +2134,7 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "alpha",
           "value": "alpha"
         },
@@ -1946,7 +2165,7 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "alpha_ip16_pg1",
           "value": "alpha_ip16_pg1"
         },
@@ -1978,7 +2197,6 @@
         "allValue": null,
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],
@@ -2032,5 +2250,5 @@
   "timezone": "browser",
   "title": "PostgreSQL Details",
   "uid": "6jtN_vfiz",
-  "version": 5
+  "version": 8
 }

--- a/grafana/common/PG_Details.json
+++ b/grafana/common/PG_Details.json
@@ -2139,7 +2139,7 @@
           "value": "alpha"
         },
         "datasource": "PROMETHEUS",
-        "definition": "label_values(up{exp_type='pg'}, cluster)",
+        "definition": "label_values(up{exp_type='pg'}, cluster_name)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2149,7 +2149,7 @@
         "name": "pgcluster",
         "options": [],
         "query": {
-          "query": "label_values(up{exp_type='pg'}, cluster)",
+          "query": "label_values(up{exp_type='pg'}, cluster_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/grafana/common/PG_Overview.json
+++ b/grafana/common/PG_Overview.json
@@ -15,86 +15,113 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 7,
-  "iteration": 1582574932240,
+  "iteration": 1617294517997,
   "links": [],
   "panels": [
     {
       "cacheTimeout": null,
-      "colorBackground": true,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(50, 172, 45, 0.9)",
-        "rgba(68, 126, 188, 0.9)"
-      ],
       "datasource": "PROMETHEUS",
-      "format": "none",
-      "gauge": {
-        "maxValue": 2,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": false
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "PG Details",
+              "url": "/d/6jtN_vfiz/postgresql-details?$__all_variables"
+            }
+          ],
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "null"
+            },
+            {
+              "id": 1,
+              "op": "=",
+              "text": "PRIMARY",
+              "type": 1,
+              "value": ".5"
+            },
+            {
+              "id": 2,
+              "op": "=",
+              "text": "REPLICA",
+              "type": 1,
+              "value": "1"
+            },
+            {
+              "id": 3,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "0"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": null
+              },
+              {
+                "color": "rgba(50, 172, 45, 0.9)",
+                "value": 0.5
+              },
+              {
+                "color": "rgba(68, 126, 188, 0.9)",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 4,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 0
       },
       "id": 1,
       "interval": null,
-      "links": [
-        {
-          "targetBlank": true,
-          "title": "PostgreSQL Details",
-          "url": "/d/6jtN_vfiz/postgresql-details?$__all_variables"
-        }
-      ],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
+      "links": [],
       "maxDataPoints": 100,
-      "maxPerRow": 8,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "options": {},
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "valueSize": 47
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.5",
       "repeat": "pgnodes",
       "repeatDirection": "h",
       "scopedVars": {
         "pgnodes": {
           "selected": false,
-          "text": "pg1",
-          "value": "pg1"
+          "text": "alpha_ip16_pg1",
+          "value": "alpha_ip16_pg1"
         }
       },
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
       "targets": [
         {
           "expr": "pg_up{job=~\"[[pgnodes]]\"} / ccp_is_in_recovery_status{job=~\"[[pgnodes]]\"}",
@@ -107,112 +134,114 @@
           "step": 2
         }
       ],
-      "thresholds": "0.5,1",
       "title": "[[pgnodes]]",
-      "type": "singlestat",
-      "valueFontSize": "70%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "DOWN",
-          "value": "null"
-        },
-        {
-          "op": "=",
-          "text": "PRIMARY",
-          "value": ".5"
-        },
-        {
-          "op": "=",
-          "text": "REPLICA",
-          "value": "1"
-        },
-        {
-          "op": "=",
-          "text": "DOWN",
-          "value": "0"
-        }
-      ],
-      "valueName": "current"
+      "type": "stat"
     },
     {
       "cacheTimeout": null,
-      "colorBackground": true,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(50, 172, 45, 0.9)",
-        "rgba(68, 126, 188, 0.9)"
-      ],
       "datasource": "PROMETHEUS",
-      "format": "none",
-      "gauge": {
-        "maxValue": 2,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": false
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "PG Details",
+              "url": "/d/6jtN_vfiz/postgresql-details?$__all_variables"
+            }
+          ],
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "null"
+            },
+            {
+              "id": 1,
+              "op": "=",
+              "text": "PRIMARY",
+              "type": 1,
+              "value": ".5"
+            },
+            {
+              "id": 2,
+              "op": "=",
+              "text": "REPLICA",
+              "type": 1,
+              "value": "1"
+            },
+            {
+              "id": 3,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "0"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": null
+              },
+              {
+                "color": "rgba(50, 172, 45, 0.9)",
+                "value": 0.5
+              },
+              {
+                "color": "rgba(68, 126, 188, 0.9)",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 4,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 8,
         "y": 0
       },
       "id": 2,
       "interval": null,
-      "links": [
-        {
-          "targetBlank": true,
-          "title": "PostgreSQL Details",
-          "url": "/d/6jtN_vfiz/postgresql-details?$__all_variables"
-        }
-      ],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
+      "links": [],
       "maxDataPoints": 100,
-      "maxPerRow": 8,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "options": {},
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "repeat": null,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "valueSize": 47
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.5",
       "repeatDirection": "h",
-      "repeatIteration": 1582574932240,
+      "repeatIteration": 1617294517997,
       "repeatPanelId": 1,
       "scopedVars": {
         "pgnodes": {
           "selected": false,
-          "text": "pg2",
-          "value": "pg2"
+          "text": "alpha_ip26_pg2",
+          "value": "alpha_ip26_pg2"
         }
       },
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
       "targets": [
         {
           "expr": "pg_up{job=~\"[[pgnodes]]\"} / ccp_is_in_recovery_status{job=~\"[[pgnodes]]\"}",
@@ -225,37 +254,132 @@
           "step": 2
         }
       ],
-      "thresholds": "0.5,1",
       "title": "[[pgnodes]]",
-      "type": "singlestat",
-      "valueFontSize": "70%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "DOWN",
-          "value": "null"
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "PG Details",
+              "url": "/d/6jtN_vfiz/postgresql-details?$__all_variables"
+            }
+          ],
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "null"
+            },
+            {
+              "id": 1,
+              "op": "=",
+              "text": "PRIMARY",
+              "type": 1,
+              "value": ".5"
+            },
+            {
+              "id": 2,
+              "op": "=",
+              "text": "REPLICA",
+              "type": 1,
+              "value": "1"
+            },
+            {
+              "id": 3,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "0"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": null
+              },
+              {
+                "color": "rgba(50, 172, 45, 0.9)",
+                "value": 0.5
+              },
+              {
+                "color": "rgba(68, 126, 188, 0.9)",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
         },
-        {
-          "op": "=",
-          "text": "PRIMARY",
-          "value": ".5"
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
         },
-        {
-          "op": "=",
-          "text": "REPLICA",
-          "value": "1"
+        "text": {
+          "valueSize": 47
         },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.5",
+      "repeatDirection": "h",
+      "repeatIteration": 1617294517997,
+      "repeatPanelId": 1,
+      "scopedVars": {
+        "pgnodes": {
+          "selected": false,
+          "text": "alpha_ip36_pg3",
+          "value": "alpha_ip36_pg3"
+        }
+      },
+      "targets": [
         {
-          "op": "=",
-          "text": "DOWN",
-          "value": "0"
+          "expr": "pg_up{job=~\"[[pgnodes]]\"} / ccp_is_in_recovery_status{job=~\"[[pgnodes]]\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "up",
+          "refId": "A",
+          "step": 2
         }
       ],
-      "valueName": "current"
+      "title": "[[pgnodes]]",
+      "type": "stat"
     }
   ],
   "refresh": "5m",
-  "schemaVersion": 21,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -263,19 +387,28 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "PROMETHEUS",
         "definition": "",
+        "description": null,
+        "error": null,
         "hide": 2,
         "includeAll": true,
         "label": "PGCluster",
         "multi": true,
         "name": "pgnodes",
         "options": [],
-        "query": "label_values(up{exp_type='pg'}, job)",
+        "query": {
+          "query": "label_values(up{exp_type='pg'}, job)",
+          "refId": "PROMETHEUS-pgnodes-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/grafana/common/PG_Overview.json
+++ b/grafana/common/PG_Overview.json
@@ -426,16 +426,6 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
     "time_options": [
       "5m",
       "15m",

--- a/grafana/common/PG_Overview.json
+++ b/grafana/common/PG_Overview.json
@@ -422,7 +422,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-2d",
     "to": "now"
   },
   "timepicker": {

--- a/grafana/common/Prometheus_Alerts.json
+++ b/grafana/common/Prometheus_Alerts.json
@@ -289,16 +289,6 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
     "time_options": [
       "5m",
       "15m",

--- a/grafana/common/QueryStatistics.json
+++ b/grafana/common/QueryStatistics.json
@@ -783,17 +783,10 @@
     ]
   },
   "time": {
-    "from": "now-24h",
+    "from": "now-2d",
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
     "time_options": [
       "5m",
       "15m",

--- a/grafana/common/QueryStatistics.json
+++ b/grafana/common/QueryStatistics.json
@@ -16,8 +16,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 14,
-  "iteration": 1599067369291,
+  "iteration": 1618858505673,
   "links": [],
   "panels": [
     {
@@ -58,12 +57,13 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "value"
       },
-      "pluginVersion": "7.1.2",
+      "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "sum(ccp_pg_stat_statements_total_calls_count{job=\"[[pgnodes]]\", dbname=~\"[[dbname]]\", role=~\"[[role]]\"})",
+          "expr": "sum(ccp_pg_stat_statements_total_calls_count{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\", role=~\"[[role]]\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -113,12 +113,13 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "value"
       },
-      "pluginVersion": "7.1.2",
+      "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "sum(ccp_pg_stat_statements_total_exec_time_ms{job=\"[[pgnodes]]\", dbname=~\"[[dbname]]\", role=~\"[[role]]\"})",
+          "expr": "sum(ccp_pg_stat_statements_total_exec_time_ms{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\", role=~\"[[role]]\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -169,12 +170,13 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "value"
       },
-      "pluginVersion": "7.1.2",
+      "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "avg(ccp_pg_stat_statements_total_mean_exec_time_ms{job=\"[[pgnodes]]\", dbname=~\"[[dbname]]\", role=~\"[[role]]\"})",
+          "expr": "avg(ccp_pg_stat_statements_total_mean_exec_time_ms{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\", role=~\"[[role]]\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -225,12 +227,13 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "value"
       },
-      "pluginVersion": "7.1.2",
+      "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "sum(ccp_pg_stat_statements_total_row_count{job=\"[[pgnodes]]\", dbname=~\"[[dbname]]\", role=~\"[[role]]\"})",
+          "expr": "sum(ccp_pg_stat_statements_total_row_count{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\", role=~\"[[role]]\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -277,8 +280,11 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.2",
+      "pluginVersion": "7.4.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -288,7 +294,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(ccp_pg_stat_statements_total_calls_count{job=\"[[pgnodes]]\", dbname=~\"[[dbname]]\", role=~\"[[role]]\"}[1m])",
+          "expr": "irate(ccp_pg_stat_statements_total_calls_count{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\", role=~\"[[role]]\"}[1m])",
           "interval": "",
           "legendFormat": "db: {{dbname}}, user: {{role}}",
           "refId": "A"
@@ -314,6 +320,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:100",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -322,6 +329,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:101",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -341,7 +349,8 @@
         "defaults": {
           "custom": {
             "align": null,
-            "displayMode": "auto"
+            "displayMode": "auto",
+            "filterable": false
           },
           "mappings": [],
           "thresholds": {
@@ -409,10 +418,10 @@
           }
         ]
       },
-      "pluginVersion": "7.1.2",
+      "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "ccp_pg_stat_statements_top_mean_exec_time_ms{job=\"[[pgnodes]]\", dbname=~\"[[dbname]]\", role=~\"[[role]]\"}",
+          "expr": "ccp_pg_stat_statements_top_mean_exec_time_ms{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\", role=~\"[[role]]\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -460,7 +469,8 @@
         "defaults": {
           "custom": {
             "align": null,
-            "displayMode": "auto"
+            "displayMode": "auto",
+            "filterable": false
           },
           "mappings": [],
           "thresholds": {
@@ -528,10 +538,10 @@
           }
         ]
       },
-      "pluginVersion": "7.1.2",
+      "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "ccp_pg_stat_statements_top_max_exec_time_ms{job=\"[[pgnodes]]\", dbname=~\"[[dbname]]\", role=~\"[[role]]\"}",
+          "expr": "ccp_pg_stat_statements_top_max_exec_time_ms{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\", role=~\"[[role]]\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -578,7 +588,8 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
-            "align": null
+            "align": null,
+            "filterable": false
           },
           "mappings": [],
           "thresholds": {
@@ -646,10 +657,10 @@
           }
         ]
       },
-      "pluginVersion": "7.1.2",
+      "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "ccp_pg_stat_statements_top_total_exec_time_ms{job=\"[[pgnodes]]\", dbname=~\"[[dbname]]\", role=~\"[[role]]\"}",
+          "expr": "ccp_pg_stat_statements_top_total_exec_time_ms{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\", dbname=~\"[[pgdatabase]]\", role=~\"[[role]]\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -693,7 +704,7 @@
     }
   ],
   "refresh": "15m",
-  "schemaVersion": 26,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -702,18 +713,60 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "pg1_crunchy",
-          "value": "pg1_crunchy"
+          "text": "crunchy",
+          "value": "crunchy"
         },
-        "datasource": "PROMETHEUS",
-        "definition": "label_values(up{exp_type='pg'}, job)",
+        "datasource": null,
+        "definition": "label_values(up{exp_type='pg'}, cluster_name)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "PGCluster",
         "multi": false,
+        "name": "pgcluster",
+        "options": [
+          {
+            "selected": true,
+            "text": "crunchy",
+            "value": "crunchy"
+          }
+        ],
+        "query": {
+          "query": "label_values(up{exp_type='pg'}, cluster_name)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "crunchy_pg1_crunchy",
+          "value": "crunchy_pg1_crunchy"
+        },
+        "datasource": "PROMETHEUS",
+        "definition": "label_values(up{exp_type='pg', cluster_name=\"[[pgcluster]]\"}, job)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Node",
+        "multi": false,
         "name": "pgnodes",
         "options": [],
-        "query": "label_values(up{exp_type='pg'}, job)",
+        "query": {
+          "query": "label_values(up{exp_type='pg', cluster_name=\"[[pgcluster]]\"}, job)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -728,20 +781,28 @@
         "allValue": null,
         "current": {
           "selected": true,
-          "text": "All",
+          "tags": [],
+          "text": [
+            "All"
+          ],
           "value": [
             "$__all"
           ]
         },
         "datasource": "PROMETHEUS",
-        "definition": "label_values(ccp_pg_stat_statements_total_calls_count{job=~\"[[pgnodes]]\"}, dbname) ",
+        "definition": "label_values(ccp_pg_stat_statements_total_calls_count{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\"}, dbname) ",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
-        "label": "dbname",
+        "label": "PGDatabase",
         "multi": true,
-        "name": "dbname",
+        "name": "pgdatabase",
         "options": [],
-        "query": "label_values(ccp_pg_stat_statements_total_calls_count{job=~\"[[pgnodes]]\"}, dbname) ",
+        "query": {
+          "query": "label_values(ccp_pg_stat_statements_total_calls_count{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\"}, dbname) ",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -756,20 +817,27 @@
         "allValue": null,
         "current": {
           "selected": true,
-          "text": "All",
+          "text": [
+            "All"
+          ],
           "value": [
             "$__all"
           ]
         },
         "datasource": "PROMETHEUS",
-        "definition": "label_values(ccp_pg_stat_statements_total_calls_count{job=~\"[[pgnodes]]\",dbname=~\"[[dbname]]\"}, role) ",
+        "definition": "label_values(ccp_pg_stat_statements_total_calls_count{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\",dbname=~\"[[pgdatabase]]\"}, role) ",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "role",
         "multi": true,
         "name": "role",
         "options": [],
-        "query": "label_values(ccp_pg_stat_statements_total_calls_count{job=~\"[[pgnodes]]\",dbname=~\"[[dbname]]\"}, role) ",
+        "query": {
+          "query": "label_values(ccp_pg_stat_statements_total_calls_count{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\",dbname=~\"[[pgdatabase]]\"}, role) ",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -802,5 +870,5 @@
   "timezone": "",
   "title": "Query Statistics (pg_stat_statements)",
   "uid": "ZKoTOHDGk",
-  "version": 16
+  "version": 2
 }

--- a/grafana/common/TableSize_Details.json
+++ b/grafana/common/TableSize_Details.json
@@ -224,16 +224,6 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
     "time_options": [
       "5m",
       "15m",

--- a/grafana/common/TableSize_Details.json
+++ b/grafana/common/TableSize_Details.json
@@ -15,8 +15,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 1,
-  "iteration": 1582574962837,
+  "iteration": 1618856334694,
   "links": [],
   "panels": [
     {
@@ -25,6 +24,13 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -49,9 +55,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -61,8 +68,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ccp_table_size_size_bytes{job=~\"[[pgnodes]]\", dbname=\"[[dbname]]\", schemaname=\"[[schemaname]]\", relname=\"[[tablename]]\"}",
+          "expr": "ccp_table_size_size_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\", dbname=\"[[pgdatabase]]\", schemaname=\"[[schemaname]]\", relname=\"[[tablename]]\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{dbname}}.{{schemaname}}.{{relname}}",
           "refId": "A",
@@ -89,6 +97,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:138",
           "format": "decbytes",
           "label": null,
           "logBase": 1,
@@ -97,6 +106,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:139",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -112,7 +122,7 @@
     }
   ],
   "refresh": "15m",
-  "schemaVersion": 21,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -120,18 +130,24 @@
       {
         "allValue": null,
         "current": {
-          "text": "pg1",
-          "value": "pg1"
+          "selected": false,
+          "text": "crunchy",
+          "value": "crunchy"
         },
         "datasource": "PROMETHEUS",
-        "definition": "",
+        "definition": "label_values(up{exp_type='pg'}, cluster_name)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "PGCluster",
         "multi": false,
-        "name": "pgnodes",
+        "name": "pgcluster",
         "options": [],
-        "query": "label_values(up{exp_type='pg'}, job)",
+        "query": {
+          "query": "label_values(up{exp_type='pg'}, cluster_name)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -145,18 +161,24 @@
       {
         "allValue": null,
         "current": {
-          "text": "sampledb",
-          "value": "sampledb"
+          "selected": true,
+          "text": "crunchy_pg1_crunchy",
+          "value": "crunchy_pg1_crunchy"
         },
         "datasource": "PROMETHEUS",
-        "definition": "",
+        "definition": "label_values(up{exp_type='pg', cluster_name=\"[[pgcluster]]\"}, job)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
-        "label": null,
+        "label": "Node",
         "multi": false,
-        "name": "dbname",
+        "name": "pgnodes",
         "options": [],
-        "query": "label_values(ccp_table_size_size_bytes{job=~\"[[pgnodes]]\"},dbname)",
+        "query": {
+          "query": "label_values(up{exp_type='pg', cluster_name=\"[[pgcluster]]\"}, job)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -170,18 +192,55 @@
       {
         "allValue": null,
         "current": {
-          "text": "information_schema",
-          "value": "information_schema"
+          "selected": true,
+          "text": "testdb",
+          "value": "testdb"
         },
         "datasource": "PROMETHEUS",
-        "definition": "",
+        "definition": "label_values(ccp_database_size_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\"}, dbname)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "PGDatabase",
+        "multi": false,
+        "name": "pgdatabase",
+        "options": [],
+        "query": {
+          "query": "label_values(ccp_database_size_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\"}, dbname)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "public",
+          "value": "public"
+        },
+        "datasource": "PROMETHEUS",
+        "definition": "label_values(ccp_table_size_size_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\",dbname=\"[[pgdatabase]]\"},schemaname)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "schemaname",
         "options": [],
-        "query": "label_values(ccp_table_size_size_bytes{job=~\"[[pgnodes]]\",dbname=\"[[dbname]]\"},schemaname)",
+        "query": {
+          "query": "label_values(ccp_table_size_size_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\",dbname=\"[[pgdatabase]]\"},schemaname)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -195,18 +254,24 @@
       {
         "allValue": null,
         "current": {
-          "text": "sql_features",
-          "value": "sql_features"
+          "selected": false,
+          "text": "bloat_indexes",
+          "value": "bloat_indexes"
         },
         "datasource": "PROMETHEUS",
-        "definition": "",
+        "definition": "label_values(ccp_table_size_size_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\",dbname=\"[[pgdatabase]]\",schemaname=\"[[schemaname]]\"},relname)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "tablename",
         "options": [],
-        "query": "label_values(ccp_table_size_size_bytes{job=~\"[[pgnodes]]\",dbname=\"[[dbname]]\",schemaname=\"[[schemaname]]\"},relname)",
+        "query": {
+          "query": "label_values(ccp_table_size_size_bytes{cluster_name=\"[[pgcluster]]\", job=\"[[pgnodes]]\",dbname=\"[[pgdatabase]]\",schemaname=\"[[schemaname]]\"},relname)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/grafana/linux/Filesystem_Details.json
+++ b/grafana/linux/Filesystem_Details.json
@@ -577,16 +577,6 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
     "time_options": [
       "5m",
       "15m",

--- a/grafana/linux/Network_Details.json
+++ b/grafana/linux/Network_Details.json
@@ -1149,19 +1149,11 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-2d",
     "to": "now"
   },
   "timepicker": {
     "now": true,
-    "refresh_intervals": [
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
     "time_options": [
       "5m",
       "15m",

--- a/grafana/linux/OS_Details.json
+++ b/grafana/linux/OS_Details.json
@@ -12,25 +12,85 @@
       }
     ]
   },
-  "editable": false,
+  "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 4,
-  "iteration": 1582574817208,
+  "iteration": 1618265425340,
   "links": [],
   "panels": [
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 12,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": false,
+        "text": {}
+      },
+      "pluginVersion": "7.4.5",
+      "targets": [
+        {
+          "expr": "node_load5{job=~\"[[osnodes]]\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "System Load (5m)",
+      "type": "gauge"
+    },
     {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 12,
-        "x": 0,
+        "w": 10,
+        "x": 4,
         "y": 0
       },
       "hiddenSeries": false,
@@ -49,9 +109,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -70,6 +131,7 @@
         {
           "expr": "node_load5{job=~\"[[osnodes]]\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "5m",
           "refId": "B"
@@ -102,6 +164,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:182",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -110,6 +173,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:183",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -129,12 +193,19 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 6,
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 12,
-        "x": 12,
+        "w": 10,
+        "x": 14,
         "y": 0
       },
       "hiddenSeries": false,
@@ -153,9 +224,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": true,
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -186,39 +258,11 @@
           "refId": "C"
         },
         {
-          "expr": "sum by (mode)(irate(node_cpu{mode=\"idle\", job=~\"[[osnodes]]\"}[5m]))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{mode}}",
-          "refId": "D"
-        },
-        {
           "expr": "sum by (mode)(irate(node_cpu_seconds_total{mode=\"system\", job=~\"[[osnodes]]\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{mode}}",
           "refId": "E"
-        },
-        {
-          "expr": "sum by (mode)(irate(node_cpu{mode=\"system\", job=~\"[[osnodes]]\"}[5m]))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{mode}}",
-          "refId": "F"
-        },
-        {
-          "expr": "sum by (mode)(irate(node_cpu{mode=\"user\", job=~\"[[osnodes]]\"}[5m]))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{mode}}",
-          "refId": "G"
-        },
-        {
-          "expr": "sum by (mode)(irate(node_cpu{mode=\"iowait\", job=~\"[[osnodes]]\"}[5m]))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{mode}}",
-          "refId": "H"
         }
       ],
       "thresholds": [],
@@ -241,6 +285,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:92",
           "format": "percent",
           "label": null,
           "logBase": 1,
@@ -249,6 +294,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:93",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -263,17 +309,88 @@
       }
     },
     {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "green",
+                "value": 25
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 0,
+        "y": 7
+      },
+      "id": 14,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "7.4.5",
+      "targets": [
+        {
+          "expr": "node_memory_MemAvailable_bytes{job=~\"[[osnodes]]\"} / node_memory_MemTotal_bytes{job=~\"[[osnodes]]\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Available Memory",
+      "type": "gauge"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 12,
-        "x": 0,
+        "w": 20,
+        "x": 4,
         "y": 7
       },
       "hiddenSeries": false,
@@ -292,9 +409,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -367,18 +485,86 @@
       }
     },
     {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 60
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 0,
+        "y": 14
+      },
+      "id": 16,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "7.4.5",
+      "targets": [
+        {
+          "expr": "1 - (node_memory_SwapFree_bytes{job=~\"[[osnodes]]\"} / node_memory_SwapTotal_bytes{job=~\"[[osnodes]]\"})",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Swap Usage",
+      "type": "gauge"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 7
+        "w": 20,
+        "x": 4,
+        "y": 14
       },
       "hiddenSeries": false,
       "id": 8,
@@ -396,9 +582,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -471,18 +658,87 @@
       }
     },
     {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 0,
+        "y": 21
+      },
+      "id": 17,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "text": {}
+      },
+      "pluginVersion": "7.4.5",
+      "targets": [
+        {
+          "expr": "100 - 100 * sum(node_filesystem_avail_bytes{device!~\"tmpfs|by-uuid\",fstype=~\"xfs|ext[234]\", job=~\"[[osnodes]]\"} / node_filesystem_size_bytes{device!~\"tmpfs|by-uuid\",fstype=~\"xfs|ext[234]\", job=~\"[[osnodes]]\"}) BY (job,device,mountpoint)",
+          "interval": "",
+          "legendFormat": "{{mountpoint}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Filesystem Usage",
+      "type": "bargauge"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 14
+        "w": 20,
+        "x": 4,
+        "y": 21
       },
       "hiddenSeries": false,
       "id": 10,
@@ -505,9 +761,10 @@
       ],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.4.5",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -519,6 +776,7 @@
         {
           "expr": "100-(100*(node_filesystem_free_bytes{job=~\"[[osnodes]]\", fstype!~\".*tmpfs.*|.*root.*|.*pipe.*\"} / node_filesystem_size_bytes{job=~\"[[osnodes]]\", fstype!~\".*tmpfs.*|.*root.*|.*pipe.*\"}))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{mountpoint}}",
           "refId": "A"
@@ -551,6 +809,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:528",
           "format": "percent",
           "label": null,
           "logBase": 1,
@@ -559,6 +818,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:529",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -574,7 +834,7 @@
     }
   ],
   "refresh": "15m",
-  "schemaVersion": 21,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -582,18 +842,24 @@
       {
         "allValue": null,
         "current": {
-          "text": "pgmonitor_cluster",
-          "value": "pgmonitor_cluster"
+          "selected": false,
+          "text": "ip16_pg1",
+          "value": "ip16_pg1"
         },
         "datasource": "PROMETHEUS",
         "definition": "",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Node",
         "multi": false,
         "name": "osnodes",
         "options": [],
-        "query": "label_values(up{exp_type='node'}, job)",
+        "query": {
+          "query": "label_values(up{exp_type='node'}, job)",
+          "refId": "PROMETHEUS-osnodes-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -626,5 +892,5 @@
   "timezone": "browser",
   "title": "OS Details",
   "uid": "4t6SO2Fik",
-  "version": 2
+  "version": 3
 }

--- a/grafana/linux/OS_Details.json
+++ b/grafana/linux/OS_Details.json
@@ -611,14 +611,6 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
     "time_options": [
       "5m",
       "15m",

--- a/grafana/linux/OS_Overview.json
+++ b/grafana/linux/OS_Overview.json
@@ -1192,7 +1192,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-2d",
     "to": "now"
   },
   "timepicker": {

--- a/grafana/linux/OS_Overview.json
+++ b/grafana/linux/OS_Overview.json
@@ -15,86 +15,106 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 11,
-  "iteration": 1582574831715,
+  "iteration": 1617294779945,
   "links": [],
   "panels": [
     {
       "cacheTimeout": null,
-      "colorBackground": true,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(68, 126, 188, 0.9)",
-        "rgba(50, 172, 45, 0.9)"
-      ],
       "datasource": "PROMETHEUS",
-      "format": "none",
-      "gauge": {
-        "maxValue": 2,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": false
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "OS Details",
+              "url": "/d/4t6SO2Fik/os-details?$__all_variables"
+            }
+          ],
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "null"
+            },
+            {
+              "id": 1,
+              "op": "=",
+              "text": "UP",
+              "type": 1,
+              "value": "1"
+            },
+            {
+              "id": 2,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "0"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": null
+              },
+              {
+                "color": "rgba(68, 126, 188, 0.9)",
+                "value": 0.5
+              },
+              {
+                "color": "rgba(50, 172, 45, 0.9)",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
+        "w": 6,
         "x": 0,
         "y": 0
       },
       "id": 1,
       "interval": null,
-      "links": [
-        {
-          "targetBlank": true,
-          "title": "OS Details",
-          "url": "/d/4t6SO2Fik/os-details?$__all_variables"
-        }
-      ],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
+      "links": [],
       "maxDataPoints": 100,
-      "maxPerRow": 8,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "options": {},
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "valueSize": 50
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.5",
       "repeat": "osnodes",
       "repeatDirection": "h",
       "scopedVars": {
         "osnodes": {
           "selected": false,
-          "text": "pg1",
-          "value": "pg1"
+          "text": "ip11_etcd1",
+          "value": "ip11_etcd1"
         }
       },
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
       "targets": [
         {
           "expr": "up{job=~\"[[osnodes]]\", exp_type=\"node\"}",
@@ -107,107 +127,107 @@
           "step": 2
         }
       ],
-      "thresholds": "0.5,0.5",
       "title": "[[osnodes]]",
-      "type": "singlestat",
-      "valueFontSize": "70%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "DOWN",
-          "value": "null"
-        },
-        {
-          "op": "=",
-          "text": "UP",
-          "value": "1"
-        },
-        {
-          "op": "=",
-          "text": "DOWN",
-          "value": "0"
-        }
-      ],
-      "valueName": "current"
+      "type": "stat"
     },
     {
       "cacheTimeout": null,
-      "colorBackground": true,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(68, 126, 188, 0.9)",
-        "rgba(50, 172, 45, 0.9)"
-      ],
       "datasource": "PROMETHEUS",
-      "format": "none",
-      "gauge": {
-        "maxValue": 2,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": false
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "OS Details",
+              "url": "/d/4t6SO2Fik/os-details?$__all_variables"
+            }
+          ],
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "null"
+            },
+            {
+              "id": 1,
+              "op": "=",
+              "text": "UP",
+              "type": 1,
+              "value": "1"
+            },
+            {
+              "id": 2,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "0"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": null
+              },
+              {
+                "color": "rgba(68, 126, 188, 0.9)",
+                "value": 0.5
+              },
+              {
+                "color": "rgba(50, 172, 45, 0.9)",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
-        "x": 8,
+        "w": 6,
+        "x": 6,
         "y": 0
       },
       "id": 2,
       "interval": null,
-      "links": [
-        {
-          "targetBlank": true,
-          "title": "OS Details",
-          "url": "/d/4t6SO2Fik/os-details?$__all_variables"
-        }
-      ],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
+      "links": [],
       "maxDataPoints": 100,
-      "maxPerRow": 8,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "options": {},
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "repeat": null,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "valueSize": 50
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.5",
       "repeatDirection": "h",
-      "repeatIteration": 1582574831715,
+      "repeatIteration": 1617294779945,
       "repeatPanelId": 1,
       "scopedVars": {
         "osnodes": {
           "selected": false,
-          "text": "pg2",
-          "value": "pg2"
+          "text": "ip12_haproxy1",
+          "value": "ip12_haproxy1"
         }
       },
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
       "targets": [
         {
           "expr": "up{job=~\"[[osnodes]]\", exp_type=\"node\"}",
@@ -220,107 +240,107 @@
           "step": 2
         }
       ],
-      "thresholds": "0.5,0.5",
       "title": "[[osnodes]]",
-      "type": "singlestat",
-      "valueFontSize": "70%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "DOWN",
-          "value": "null"
-        },
-        {
-          "op": "=",
-          "text": "UP",
-          "value": "1"
-        },
-        {
-          "op": "=",
-          "text": "DOWN",
-          "value": "0"
-        }
-      ],
-      "valueName": "current"
+      "type": "stat"
     },
     {
       "cacheTimeout": null,
-      "colorBackground": true,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(68, 126, 188, 0.9)",
-        "rgba(50, 172, 45, 0.9)"
-      ],
       "datasource": "PROMETHEUS",
-      "format": "none",
-      "gauge": {
-        "maxValue": 2,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": false
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "OS Details",
+              "url": "/d/4t6SO2Fik/os-details?$__all_variables"
+            }
+          ],
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "null"
+            },
+            {
+              "id": 1,
+              "op": "=",
+              "text": "UP",
+              "type": 1,
+              "value": "1"
+            },
+            {
+              "id": 2,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "0"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": null
+              },
+              {
+                "color": "rgba(68, 126, 188, 0.9)",
+                "value": 0.5
+              },
+              {
+                "color": "rgba(50, 172, 45, 0.9)",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
-        "x": 16,
+        "w": 6,
+        "x": 12,
         "y": 0
       },
       "id": 3,
       "interval": null,
-      "links": [
-        {
-          "targetBlank": true,
-          "title": "OS Details",
-          "url": "/d/4t6SO2Fik/os-details?$__all_variables"
-        }
-      ],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
+      "links": [],
       "maxDataPoints": 100,
-      "maxPerRow": 8,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "options": {},
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "repeat": null,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "valueSize": 50
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.5",
       "repeatDirection": "h",
-      "repeatIteration": 1582574831715,
+      "repeatIteration": 1617294779945,
       "repeatPanelId": 1,
       "scopedVars": {
         "osnodes": {
           "selected": false,
-          "text": "pgmonitor_cluster",
-          "value": "pgmonitor_cluster"
+          "text": "ip13_pgbouncer1",
+          "value": "ip13_pgbouncer1"
         }
       },
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
       "targets": [
         {
           "expr": "up{job=~\"[[osnodes]]\", exp_type=\"node\"}",
@@ -333,32 +353,803 @@
           "step": 2
         }
       ],
-      "thresholds": "0.5,0.5",
       "title": "[[osnodes]]",
-      "type": "singlestat",
-      "valueFontSize": "70%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "DOWN",
-          "value": "null"
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "OS Details",
+              "url": "/d/4t6SO2Fik/os-details?$__all_variables"
+            }
+          ],
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "null"
+            },
+            {
+              "id": 1,
+              "op": "=",
+              "text": "UP",
+              "type": 1,
+              "value": "1"
+            },
+            {
+              "id": 2,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "0"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": null
+              },
+              {
+                "color": "rgba(68, 126, 188, 0.9)",
+                "value": 0.5
+              },
+              {
+                "color": "rgba(50, 172, 45, 0.9)",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "none"
         },
-        {
-          "op": "=",
-          "text": "UP",
-          "value": "1"
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
         },
+        "text": {
+          "valueSize": 50
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.5",
+      "repeatDirection": "h",
+      "repeatIteration": 1617294779945,
+      "repeatPanelId": 1,
+      "scopedVars": {
+        "osnodes": {
+          "selected": false,
+          "text": "ip14_pgmonitor1",
+          "value": "ip14_pgmonitor1"
+        }
+      },
+      "targets": [
         {
-          "op": "=",
-          "text": "DOWN",
-          "value": "0"
+          "expr": "up{job=~\"[[osnodes]]\", exp_type=\"node\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "up",
+          "refId": "A",
+          "step": 2
         }
       ],
-      "valueName": "current"
+      "title": "[[osnodes]]",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "OS Details",
+              "url": "/d/4t6SO2Fik/os-details?$__all_variables"
+            }
+          ],
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "null"
+            },
+            {
+              "id": 1,
+              "op": "=",
+              "text": "UP",
+              "type": 1,
+              "value": "1"
+            },
+            {
+              "id": 2,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "0"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": null
+              },
+              {
+                "color": "rgba(68, 126, 188, 0.9)",
+                "value": 0.5
+              },
+              {
+                "color": "rgba(50, 172, 45, 0.9)",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 4
+      },
+      "id": 5,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "valueSize": 50
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.5",
+      "repeatDirection": "h",
+      "repeatIteration": 1617294779945,
+      "repeatPanelId": 1,
+      "scopedVars": {
+        "osnodes": {
+          "selected": false,
+          "text": "ip15_backrest1",
+          "value": "ip15_backrest1"
+        }
+      },
+      "targets": [
+        {
+          "expr": "up{job=~\"[[osnodes]]\", exp_type=\"node\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "up",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "title": "[[osnodes]]",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "OS Details",
+              "url": "/d/4t6SO2Fik/os-details?$__all_variables"
+            }
+          ],
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "null"
+            },
+            {
+              "id": 1,
+              "op": "=",
+              "text": "UP",
+              "type": 1,
+              "value": "1"
+            },
+            {
+              "id": 2,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "0"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": null
+              },
+              {
+                "color": "rgba(68, 126, 188, 0.9)",
+                "value": 0.5
+              },
+              {
+                "color": "rgba(50, 172, 45, 0.9)",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 4
+      },
+      "id": 6,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "valueSize": 50
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.5",
+      "repeatDirection": "h",
+      "repeatIteration": 1617294779945,
+      "repeatPanelId": 1,
+      "scopedVars": {
+        "osnodes": {
+          "selected": false,
+          "text": "ip16_pg1",
+          "value": "ip16_pg1"
+        }
+      },
+      "targets": [
+        {
+          "expr": "up{job=~\"[[osnodes]]\", exp_type=\"node\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "up",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "title": "[[osnodes]]",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "OS Details",
+              "url": "/d/4t6SO2Fik/os-details?$__all_variables"
+            }
+          ],
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "null"
+            },
+            {
+              "id": 1,
+              "op": "=",
+              "text": "UP",
+              "type": 1,
+              "value": "1"
+            },
+            {
+              "id": 2,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "0"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": null
+              },
+              {
+                "color": "rgba(68, 126, 188, 0.9)",
+                "value": 0.5
+              },
+              {
+                "color": "rgba(50, 172, 45, 0.9)",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 4
+      },
+      "id": 7,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "valueSize": 50
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.5",
+      "repeatDirection": "h",
+      "repeatIteration": 1617294779945,
+      "repeatPanelId": 1,
+      "scopedVars": {
+        "osnodes": {
+          "selected": false,
+          "text": "ip21_etcd2",
+          "value": "ip21_etcd2"
+        }
+      },
+      "targets": [
+        {
+          "expr": "up{job=~\"[[osnodes]]\", exp_type=\"node\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "up",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "title": "[[osnodes]]",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "OS Details",
+              "url": "/d/4t6SO2Fik/os-details?$__all_variables"
+            }
+          ],
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "null"
+            },
+            {
+              "id": 1,
+              "op": "=",
+              "text": "UP",
+              "type": 1,
+              "value": "1"
+            },
+            {
+              "id": 2,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "0"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": null
+              },
+              {
+                "color": "rgba(68, 126, 188, 0.9)",
+                "value": 0.5
+              },
+              {
+                "color": "rgba(50, 172, 45, 0.9)",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 4
+      },
+      "id": 8,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "valueSize": 50
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.5",
+      "repeatDirection": "h",
+      "repeatIteration": 1617294779945,
+      "repeatPanelId": 1,
+      "scopedVars": {
+        "osnodes": {
+          "selected": false,
+          "text": "ip26_pg2",
+          "value": "ip26_pg2"
+        }
+      },
+      "targets": [
+        {
+          "expr": "up{job=~\"[[osnodes]]\", exp_type=\"node\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "up",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "title": "[[osnodes]]",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "OS Details",
+              "url": "/d/4t6SO2Fik/os-details?$__all_variables"
+            }
+          ],
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "null"
+            },
+            {
+              "id": 1,
+              "op": "=",
+              "text": "UP",
+              "type": 1,
+              "value": "1"
+            },
+            {
+              "id": 2,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "0"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": null
+              },
+              {
+                "color": "rgba(68, 126, 188, 0.9)",
+                "value": 0.5
+              },
+              {
+                "color": "rgba(50, 172, 45, 0.9)",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 8
+      },
+      "id": 9,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "valueSize": 50
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.5",
+      "repeatDirection": "h",
+      "repeatIteration": 1617294779945,
+      "repeatPanelId": 1,
+      "scopedVars": {
+        "osnodes": {
+          "selected": false,
+          "text": "ip31_etcd3",
+          "value": "ip31_etcd3"
+        }
+      },
+      "targets": [
+        {
+          "expr": "up{job=~\"[[osnodes]]\", exp_type=\"node\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "up",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "title": "[[osnodes]]",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "OS Details",
+              "url": "/d/4t6SO2Fik/os-details?$__all_variables"
+            }
+          ],
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "null"
+            },
+            {
+              "id": 1,
+              "op": "=",
+              "text": "UP",
+              "type": 1,
+              "value": "1"
+            },
+            {
+              "id": 2,
+              "op": "=",
+              "text": "DOWN",
+              "type": 1,
+              "value": "0"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": null
+              },
+              {
+                "color": "rgba(68, 126, 188, 0.9)",
+                "value": 0.5
+              },
+              {
+                "color": "rgba(50, 172, 45, 0.9)",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 8
+      },
+      "id": 10,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "valueSize": 50
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.5",
+      "repeatDirection": "h",
+      "repeatIteration": 1617294779945,
+      "repeatPanelId": 1,
+      "scopedVars": {
+        "osnodes": {
+          "selected": false,
+          "text": "ip36_pg3",
+          "value": "ip36_pg3"
+        }
+      },
+      "targets": [
+        {
+          "expr": "up{job=~\"[[osnodes]]\", exp_type=\"node\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "up",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "title": "[[osnodes]]",
+      "type": "stat"
     }
   ],
   "refresh": "5m",
-  "schemaVersion": 21,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -366,19 +1157,28 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "PROMETHEUS",
         "definition": "",
+        "description": null,
+        "error": null,
         "hide": 2,
         "includeAll": true,
         "label": "Node",
         "multi": true,
         "name": "osnodes",
         "options": [],
-        "query": "label_values(up{exp_type='node'}, job)",
+        "query": {
+          "query": "label_values(up{exp_type='node'}, job)",
+          "refId": "PROMETHEUS-osnodes-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/grafana/linux/OS_Overview.json
+++ b/grafana/linux/OS_Overview.json
@@ -1196,16 +1196,6 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
     "time_options": [
       "5m",
       "15m",

--- a/hugo/content/changelog/_index.md
+++ b/hugo/content/changelog/_index.md
@@ -3,6 +3,28 @@ title: "Changelog"
 draft: false
 weight: 5
 ---
+## 4.5
+
+### New Features
+  * Minimum required version of Grafana has been updated to 7.4.x
+  * Updated Grafana Overview dashboards to support new Stat panel
+  * Updated PostgreSQL Details Grafana dashboard with more information and to be able to present data grouped by clusters. The pgBackRest panel was removed from this dashboard.
+  * pgBackRest Grafana dashboard now presents data on a per-stanza basis
+  * Removed deprecated node_exporter metrics from Grafana OS Details dashboard. Reorganized panels.
+  * Added a basic Network Activity dashboard to Grafana using default metrics that come with node_exporter.
+  * pgMonitor repository has been reorganized to better delineate which platforms specific files apply to. Some files have also been renamed as part of this reorganization:
+  * Extended the default alert threshold for pgBackRest backups to give a buffer time and avoid false positives when backup runtimes vary.
+  * Added a default alert for PostgreSQL failover that should work in any scenario to produce an alert should the recovery status of a PostgreSQL database change (replica -> primary or primary -> replica). Note that this alert will auto-resolve after 5 minutes (by default) since it is just looking for recent state changes. The alert is meant to be acted upon immediately to see what may have occured on the systems involved.
+  * Added metric to monitor and alert on blocked queries
+  
+### Bug Fixes
+  * Fixed pgBackRest metrics not reporting all backups in all stanzas for a given repository in some configuration setups. Each database will now only report back monitoring for the stanzas that are part of its own instance. Previously all database instances reported back all stanzas in the target repository.
+  * Fixed incorrect metric name in warning alert for available memory in linux/node_exporter default alerts (node_memory_Available_bytes should be node_memory_MemAvailable_bytes)
+
+### Manual Intervention Changes
+  * pgBackRest monitoring has been expanded to better support more configuration layouts to address the above bug fix. The pgbackrest-info.sh script has been updated as part of this and this also requires re-running the setup SQL script to update the monitoring function within the database. Note again that the setup script name has changed from "setup_pg11.sql" to "setup.sql", so be sure you are running the setup script from the properly versioned folder.
+  * For the PostgreSQL Grafana dashboards to be able to choose data to present on a per-cluster basis, a new custom label must be added to all PostgreSQL targets in Prometheus. Note that this change will cause all PostgreSQL metrics to be displayed with different colors in Grafana and when displaying a time period before and after this change, data may appear to be duplicated according to the Legend.
+
 ## 4.4
 
 ### New Features

--- a/hugo/content/changelog/_index.md
+++ b/hugo/content/changelog/_index.md
@@ -20,6 +20,7 @@ weight: 5
 ### Bug Fixes
   * Fixed pgBackRest metrics not reporting all backups in all stanzas for a given repository in some configuration setups. Each database will now only report back monitoring for the stanzas that are part of its own instance. Previously all database instances reported back all stanzas in the target repository.
   * Fixed incorrect metric name in warning alert for available memory in linux/node_exporter default alerts (node_memory_Available_bytes should be node_memory_MemAvailable_bytes)
+  * Fixed incorrect title of panel on Grafana PostgreSQL Details dashboard from "Transactions Per Minute" to "Transactions Per Second".
 
 ### Manual Intervention Changes
   * pgBackRest monitoring has been expanded to better support more configuration layouts to address the above bug fix. The pgbackrest-info.sh script has been updated as part of this and this also requires re-running the setup SQL script to update the monitoring function within the database. Note again that the setup script name has changed from "setup_pg11.sql" to "setup.sql", so be sure you are running the setup script from the properly versioned folder.

--- a/hugo/content/changelog/_index.md
+++ b/hugo/content/changelog/_index.md
@@ -24,7 +24,7 @@ weight: 5
 
 ### Manual Intervention Changes
   * pgBackRest monitoring has been expanded to better support more configuration layouts to address the above bug fix. The pgbackrest-info.sh script has been updated as part of this and this also requires re-running the setup SQL script to update the monitoring function within the database. Note again that the setup script name has changed from "setup_pg11.sql" to "setup.sql", so be sure you are running the setup script from the properly versioned folder.
-  * For the PostgreSQL Grafana dashboards to be able to choose data to present on a per-cluster basis, a new custom label must be added to all PostgreSQL targets in Prometheus. Note that this change will cause all PostgreSQL metrics to be displayed with different colors in Grafana and when displaying a time period before and after this change, data may appear to be duplicated according to the Legend.
+  * For the PostgreSQL Grafana dashboards to be able to choose data to present on a per-cluster basis, a new custom label (`cluster_name`) must be added to all PostgreSQL targets in Prometheus. Note that this change will cause all PostgreSQL metrics to change colors from the point of the change forward. Also when displaying a time period before and after this change, duplicated Legend items may appear.
 
 ## 4.4
 

--- a/postgres_exporter/common/queries_global.yml
+++ b/postgres_exporter/common/queries_global.yml
@@ -188,15 +188,27 @@ ccp_transaction_wraparound:
 
 ccp_archive_command_status:
     query: "SELECT CASE 
-        WHEN EXTRACT(epoch from (last_failed_time - last_archived_time)) IS NULL THEN 0
-        WHEN EXTRACT(epoch from (last_failed_time - last_archived_time)) < 0 THEN 0
-        ELSE EXTRACT(epoch from (last_failed_time - last_archived_time)) 
-END AS seconds_since_last_fail
-FROM pg_catalog.pg_stat_archiver"
+                WHEN EXTRACT(epoch from (last_failed_time - last_archived_time)) IS NULL THEN 0
+                WHEN EXTRACT(epoch from (last_failed_time - last_archived_time)) < 0 THEN 0
+                ELSE EXTRACT(epoch from (last_failed_time - last_archived_time)) 
+                END AS seconds_since_last_fail
+            , EXTRACT(epoch from (CURRENT_TIMESTAMP - last_archived_time)) AS seconds_since_last_archive
+            , archived_count
+            , failed_count
+            FROM pg_catalog.pg_stat_archiver"
     metrics:
         - seconds_since_last_fail:
             usage: "GAUGE"
             description: "Seconds since the last recorded failure of the archive_command"
+        - seconds_since_last_archive:
+            usage: "GAUGE"
+            description: "Seconds since the last successful archive operation"
+        - archived_count:
+            usage: "GAUGE"
+            description: "Number of WAL files that have been successfully archived"
+        - failed_count:
+            usage: "GAUGE"
+            description: "Number of failed attempts for archiving WAL files"
 
 
 ccp_sequence_exhaustion:

--- a/prometheus/common/auto.d/ProductionDB.yml.example
+++ b/prometheus/common/auto.d/ProductionDB.yml.example
@@ -13,4 +13,4 @@
   labels:
     job: "Prod"
     exp_type: "pg"
-    cluster: "crunchy"
+    cluster_name: "crunchy"

--- a/prometheus/common/auto.d/ProductionDB.yml.example
+++ b/prometheus/common/auto.d/ProductionDB.yml.example
@@ -8,3 +8,9 @@
   labels:
     job: "Prod"
     exp_type: "pg"
+    cluster: "crunchy"
+- targets: [ "10.123.202.12:9188" ]
+  labels:
+    job: "Prod"
+    exp_type: "pg"
+    cluster: "crunchy"

--- a/prometheus/common/auto.d/ProductionDB.yml.example
+++ b/prometheus/common/auto.d/ProductionDB.yml.example
@@ -11,6 +11,6 @@
     cluster: "crunchy"
 - targets: [ "10.123.202.12:9188" ]
   labels:
-    job: "Prod"
+    job: "mycluster_Prod"
     exp_type: "pg"
-    cluster_name: "crunchy"
+    cluster_name: "mycluster"

--- a/prometheus/common/auto.d/ReplicaDB.yml.example
+++ b/prometheus/common/auto.d/ReplicaDB.yml.example
@@ -13,4 +13,4 @@
   labels:
     job: "Replica"
     exp_type: "pg"
-    cluster: "crunchy"
+    cluster_name: "crunchy"

--- a/prometheus/common/auto.d/ReplicaDB.yml.example
+++ b/prometheus/common/auto.d/ReplicaDB.yml.example
@@ -8,3 +8,9 @@
   labels:
     job: "Replica"
     exp_type: "pg"
+    cluster: "crunchy"
+- targets: [ "10.123.202.13:9188" ]
+  labels:
+    job: "Replica"
+    exp_type: "pg"
+    cluster: "crunchy"

--- a/prometheus/common/auto.d/ReplicaDB.yml.example
+++ b/prometheus/common/auto.d/ReplicaDB.yml.example
@@ -11,6 +11,6 @@
     cluster: "crunchy"
 - targets: [ "10.123.202.13:9188" ]
   labels:
-    job: "Replica"
+    job: "mycluster_Replica"
     exp_type: "pg"
-    cluster_name: "crunchy"
+    cluster_name: "mycluster"

--- a/prometheus/linux/alert-rules.d/crunchy-alert-rules-node.yml.example
+++ b/prometheus/linux/alert-rules.d/crunchy-alert-rules-node.yml.example
@@ -73,7 +73,7 @@ groups:
       description: 'System load for target {{ $labels.job }} is high ({{ $value }})'
 
   - alert: MemoryAvailable
-    expr: (100 * (node_memory_Available_bytes) / node_memory_MemTotal_bytes) < 25
+    expr: (100 * (node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes) < 25
     for: 1m
     labels:
       service: system

--- a/prometheus/linux/crunchy-prometheus.yml
+++ b/prometheus/linux/crunchy-prometheus.yml
@@ -46,7 +46,7 @@ scrape_configs:
   ## Monitoring for tcp services that don't have an associated exporter can be accomplished using the tcp probe 
   ##   of the blackbox_exporter provided by the Prometheus developers.
   ## Note this only provides a simple up/down that the service is listening on the given IP/port.
-  ## If an exporter is available, you can either use a blackbox probe or an Absense alert for each node
+  ## If an exporter is available, an Absence alert for each node is recommended over a blackbox probe.
   ## Below is an example to monitor the services indicated by the comment. 
   ## The "targets" list is all that should need to be edited to customize to your setup assuming blackbox_exporter runs
   ##   on same system as Prometheus.

--- a/prometheus/linux/crunchy-prometheus.yml
+++ b/prometheus/linux/crunchy-prometheus.yml
@@ -46,7 +46,7 @@ scrape_configs:
   ## Monitoring for tcp services that don't have an associated exporter can be accomplished using the tcp probe 
   ##   of the blackbox_exporter provided by the Prometheus developers.
   ## Note this only provides a simple up/down that the service is listening on the given IP/port.
-  ## If an exporter is available, it is advised to use an Absence alert vs the blackbox probe.  
+  ## If an exporter is available, you can either use a blackbox probe or an Absense alert for each node
   ## Below is an example to monitor the services indicated by the comment. 
   ## The "targets" list is all that should need to be edited to customize to your setup assuming blackbox_exporter runs
   ##   on same system as Prometheus.


### PR DESCRIPTION
# Description  

Update dashboards to remove deprecated SingleStat panel and use new Stats panel. Use data links on Overview dashboards.

Incorporate changes from container dashboards.

## Type of change  
Please check all options that are relevant  
- [ ] Bug fix (change which fixes an issue)  
- [x] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  

**Tested Configuration**:  
- [ ] CentOS, Specify version(s):  
- [ ] PostgreQL, Specify version(s):  
- [ ] docs tested with hugo <0.60  

Tested with playbook(s):  
# Checklist:  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  

