### PR TITLE
Add template for bootstrapping Alertmanager for containers

### DIFF
--- a/alertmanager/common/crunchy-alertmanager.yml
+++ b/alertmanager/common/crunchy-alertmanager.yml
@@ -8,6 +8,7 @@
 global:
     smtp_smarthost: 'localhost: 25'
     smtp_require_tls: false
+    smtp_from: 'Alertmanager <abc@yahoo.com>'
 #    smtp_smarthost: 'smtp.example.com:587'
 #    smtp_from: 'Alertmanager <abc@yahoo.com>'
 #    smtp_auth_username: '<username>'


### PR DESCRIPTION
# Description  

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

This uses a template that was found in pgMonitor v4.4 and allows for containers users to begin configuration from this template.

## Type of change  
Please check all options that are relevant  
- [x] Bug fix (change which fixes an issue)  
- [ ] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  

**Tested Configuration**:  
- [x] CentOS, Specify version(s):  CentOS 8
- [x] PostgreQL, Specify version(s):  13
- [ ] docs tested with hugo <0.60  

Tested with playbook(s):  
# Checklist:  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  

