### PR TITLE
Fixes since 4.5RC2 testing

### DIFF
--- a/grafana/common/PG_Overview.json
+++ b/grafana/common/PG_Overview.json
@@ -422,7 +422,7 @@
     ]
   },
   "time": {
-    "from": "now-2d",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {

--- a/grafana/linux/OS_Overview.json
+++ b/grafana/linux/OS_Overview.json
@@ -1192,7 +1192,7 @@
     ]
   },
   "time": {
-    "from": "now-2d",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {

--- a/postgres_exporter/common/pg12/queries_pg_stat_statements_reset_info.yml
+++ b/postgres_exporter/common/pg12/queries_pg_stat_statements_reset_info.yml
@@ -1,6 +1,6 @@
 ###
 #
-# Begin File: queries_pg_stat_statements_reset.yml
+# Begin File: pg_stat_statements_reset_info.yml
 #
 # Copyright 2017-2021 Crunchy Data Solutions, Inc. All Rights Reserved.
 #
@@ -14,7 +14,7 @@ ccp_pg_stat_statements_reset:
 
 ###
 #
-# End File: queries_pg_stat_statements_reset.yml
+# End File: pg_stat_statements_reset_info.yml
 #
 ###
 

--- a/postgres_exporter/common/pg13/queries_pg_stat_statements_reset_info.yml
+++ b/postgres_exporter/common/pg13/queries_pg_stat_statements_reset_info.yml
@@ -1,0 +1,20 @@
+###
+#
+# Begin File: pg_stat_statements_reset_info.yml
+#
+# Copyright 2017-2021 Crunchy Data Solutions, Inc. All Rights Reserved.
+#
+###
+ccp_pg_stat_statements_reset:
+  query: "select monitor.pg_stat_statements_reset_info(#PG_STAT_STATEMENTS_THROTTLE_MINUTES#) as time"
+  metrics:
+    - time:
+        usage: "GAUGE"
+        description: "Epoch time when stats were reset"
+
+###
+#
+# End File: pg_stat_statements_reset_info.yml
+#
+###
+


### PR DESCRIPTION
# Description  

The overview dashboards are still not consistently showing the "current" value when set to a longer default timeframe. Set back to "5m" to ensure it's only looking at the last 5 minutes of data to keep the status more current.

Move the pg_stat_statements reset function to the pg12/13 folder since it is only supported in those versions.

## Type of change  
Please check all options that are relevant  
- [x] Bug fix (change which fixes an issue)  
- [ ] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  

**Tested Configuration**:  
- [x] CentOS, Specify version(s):  CentOS7
- [x] PostgreQL, Specify version(s):  11, 13
- [ ] docs tested with hugo <0.60  

Tested with playbook(s):  
# Checklist:  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  

