### PR TITLE
keep codeowners and templates in lockstep w/ paar

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @hunleyd @keithf4 @sharmay
+*   @hunleyd @keithf4 @pgguru @sharmay

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'STATUS: UNCONFIRMED'
+labels: 'UNCONFIRMED'
 assignees: ''
 
 ---
@@ -14,9 +14,9 @@ assignees: ''
 
 
 **Tell us about your environment:**  
-- pgMonitor Version:
-- PostgreSQL Version:  
 - Operating System:  
-- Exporter in use:  
-- Virtualization:  
-- Any customization:  
+- PostgreSQL Version:  
+- Ansible Version:  
+- Roles version or branch:  
+- Inventory and Playbook (names):  
+- Changes to stock Roles, Inventory, Playbook:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ assignees: ''
 - Container name / image:  
 - Operating System for non-container:  
 - PostgreSQL Version:  
-- Exporter in use:  
+- Exporter(s) in use (incl. version):  
 - Prometheus version:  
 - AlertManager version:  
 - Grafana version:  

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,9 +14,12 @@ assignees: ''
 
 
 **Tell us about your environment:**  
-- Operating System:  
+- pgMonitor version:  
+- Container or non-container:  
+- Container name / image:  
+- Operating System for non-container:  
 - PostgreSQL Version:  
-- Ansible Version:  
-- Roles version or branch:  
-- Inventory and Playbook (names):  
-- Changes to stock Roles, Inventory, Playbook:
+- Exporter in use:  
+- Prometheus version:  
+- AlertManager version:  
+- Grafana version:  

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an enhancement for this project
 title: ''
-labels: 'STATUS: UNCONFIRMED'
+labels: 'UNCONFIRMED'
 assignees: ''
 
 ---

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,7 @@ Please check all options that are relevant
 - [ ] Ansible, Specify version(s):  
 - [ ] Specify Distro & version(s):  
 - [ ] Specify Package distro & version(s):  
+- [ ] Packages compiled from source & their version:  
 - [ ] PostgreSQL, Specify version(s):  
 - [ ] docs tested with hugo version(s):  
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ Please check all options that are relevant
 **Tested Configuration**:  
 - [ ] Ansible, Specify version(s):  
 - [ ] Specify Distro & version(s):  
-- [ ] Specify Repo Distro & version(s):  
+- [ ] Specify Package distro & version(s):  
 - [ ] PostgreSQL, Specify version(s):  
 - [ ] docs tested with hugo version(s):  
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,8 +18,8 @@ Please check all options that are relevant
 - [ ] Ansible, Specify version(s):  
 - Installation method:  
     - [ ] Binary install from source, version:  
-    - [ ] OS ackage repository, distro and version:  
-    - [ ] Local package session, version:  
+    - [ ] OS package repository, distro, and version:  
+    - [ ] Local package server, version:  
     - [ ] Custom-built package, version:  
     - [ ] Other:  
 - [ ] PostgreSQL, Specify version(s):  

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,13 +16,17 @@ Please check all options that are relevant
 # How Has This Been Tested?  
 **Tested Configuration**:  
 - [ ] Ansible, Specify version(s):  
-- [ ] Specify Distro & version(s):  
-- [ ] Specify Package distro & version(s):  
-- [ ] Packages compiled from source & their version:  
+- Installation method:  
+    - [ ] Binary install from source, version:  
+    - [ ] OS ackage repository, distro and version:  
+    - [ ] Local package session, version:  
+    - [ ] Custom-built package, version:  
+    - [ ] Other:  
 - [ ] PostgreSQL, Specify version(s):  
 - [ ] docs tested with hugo version(s):  
 
 Tested with playbook(s):  
+
 # Checklist:  
 - [ ] My changes generate no new lint warnings  
 - I have made corresponding changes to:  

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,9 +2,9 @@
 
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
 
-Fixes (issue) #  
+Fixes #  
 
-Depends on (issue) #  
+Depends on #  
 
 ## Type of change  
 Please check all options that are relevant  
@@ -14,16 +14,17 @@ Please check all options that are relevant
 - [ ] Documentation update only  
 
 # How Has This Been Tested?  
-
 **Tested Configuration**:  
-- [ ] CentOS, Specify version(s):  
-- [ ] PostgreQL, Specify version(s):  
-- [ ] docs tested with hugo <0.60  
+- [ ] Ansible, Specify version(s):  
+- [ ] Specify Distro & version(s):  
+- [ ] Specify Repo Distro & version(s):  
+- [ ] PostgreSQL, Specify version(s):  
+- [ ] docs tested with hugo version(s):  
 
 Tested with playbook(s):  
 # Checklist:  
+- [ ] My changes generate no new lint warnings  
 - I have made corresponding changes to:  
     - [ ] the documentation  
     - [ ] the release notes  
     - [ ] the upgrade doc  
-


### PR DESCRIPTION
# Description  

Keep the .github folder consistent between paar and pgm

Fixes (issue) #  

Depends on (issue) #  

## Type of change  
Please check all options that are relevant  
- [ ] Bug fix (change which fixes an issue)  
- [ ] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  

**Tested Configuration**:  
- [ ] CentOS, Specify version(s):  
- [ ] PostgreQL, Specify version(s):  
- [ ] docs tested with hugo <0.60  

Tested with playbook(s):  
# Checklist:  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  

