### PR TITLE
Fix stat queries and add a few missing metrics

### DIFF
--- a/postgres_exporter/common/queries_nodemx.yml
+++ b/postgres_exporter/common/queries_nodemx.yml
@@ -37,7 +37,7 @@ with d(key, val) as
 (select key, val from monitor.cgroup_setof_kv('memory.stat'))
 SELECT
  monitor.kdapi_scalar_bigint('mem_request') as request,
- monitor.cgroup_scalar_bigint('memory.limit_in_bytes') as limit,
+case when monitor.cgroup_scalar_bigint('memory.limit_in_bytes') = 9223372036854771712 then 0 else monitor.cgroup_scalar_bigint('memory.limit_in_bytes') end as limit,
  (select val from d where key='cache') as cache,
  (select val from d where key='rss') as rss,
  (select val from d where key='shmem') as shmem,

--- a/postgres_exporter/common/queries_nodemx.yml
+++ b/postgres_exporter/common/queries_nodemx.yml
@@ -32,7 +32,24 @@ ccp_nodemx_process:
 
 
 ccp_nodemx_mem:
-  query: "SELECT monitor.kdapi_scalar_bigint('mem_request') as request, monitor.kdapi_scalar_bigint('mem_limit') as limit, (select val from monitor.cgroup_setof_kv('memory.stat') where key='cache') as cache, (select val from monitor.cgroup_setof_kv('memory.stat') where key='rss') as rss, (select val from monitor.cgroup_setof_kv('memory.stat') where key='shmem') as shmem, (select val from monitor.cgroup_setof_kv('memory.stat') where key='mapped_file') as mapped_file, (select val from monitor.cgroup_setof_kv('memory.stat') where key='dirty') as dirty, (select val from monitor.cgroup_setof_kv('memory.stat') where key='active_anon') as active_anon, (select val from monitor.cgroup_setof_kv('memory.stat') where key='inactive_anon') as inactive_anon, (select val from monitor.cgroup_setof_kv('memory.stat') where key='active_file') as active_file, (select val from monitor.cgroup_setof_kv('memory.stat') where key='inactive_file') as inactive_file"
+  query: "
+with d(key, val) as
+(select key, val from monitor.cgroup_setof_kv('memory.stat'))
+SELECT
+ monitor.kdapi_scalar_bigint('mem_request') as request,
+ monitor.cgroup_scalar_bigint('memory.limit_in_bytes') as limit,
+ (select val from d where key='cache') as cache,
+ (select val from d where key='rss') as rss,
+ (select val from d where key='shmem') as shmem,
+ (select val from d where key='mapped_file') as mapped_file,
+ (select val from d where key='dirty') as dirty,
+ (select val from d where key='active_anon') as active_anon,
+ (select val from d where key='inactive_anon') as inactive_anon,
+ (select val from d where key='active_file') as active_file,
+ (select val from d where key='inactive_file') as inactive_file,
+ monitor.cgroup_scalar_bigint('memory.usage_in_bytes') as usage_in_bytes,
+ monitor.cgroup_scalar_bigint('memory.kmem.usage_in_bytes') as kmem_usage_in_bytes
+"
   metrics:
     - request:
         usage: "GAUGE"
@@ -52,9 +69,6 @@ ccp_nodemx_mem:
     - mapped_file:
         usage: "GAUGE"
         description: "Total bytes of mapped file (includes tmpfs/shmem)"
-    - mapped_file:
-        usage: "GAUGE"
-        description: "Total bytes of mapped file (includes tmpfs/shmem)"
     - dirty:
         usage: "GAUGE"
         description: "Total bytes that are waiting to get written back to the disk"
@@ -70,6 +84,12 @@ ccp_nodemx_mem:
     - inactive_file:
         usage: "GAUGE"
         description: "Total bytes of file-backed memory on inactive LRU list"
+    - usage_in_bytes:
+        usage: "GAUGE"
+        description: "Total usage in bytes"
+    - kmem_usage_in_bytes:
+        usage: "GAUGE"
+        description: "Total kernel memory usage in bytes"
 
 
 ccp_nodemx_cpu:
@@ -93,16 +113,24 @@ ccp_nodemx_cpucfs:
         description: "the length of a period (in microseconds)"
 
 ccp_nodemx_cpuacct:
-  query: "SELECT monitor.cgroup_scalar_bigint('cpuacct.usage') as usage"
+  query: "SELECT monitor.cgroup_scalar_bigint('cpuacct.usage') as usage, clock_timestamp() as usage_ts"
   metrics:
     - usage:
         usage: "GAUGE"
         description: "CPU usage in nanoseconds"
+    - usage_ts:
+        usage: "GAUGE"
+        description: "CPU usage snapshot timestamp"
 
 ccp_nodemx_cpustat:
-  query: "select (SELECT val as nr_periods FROM monitor.cgroup_setof_kv('cpu.stat') where key='nr_periods'), (SELECT val as nr_throttled FROM monitor.cgroup_setof_kv('cpu.stat') where key='nr_throttled'), (SELECT val as throttled_time FROM monitor.cgroup_setof_kv('cpu.stat') where key='throttled_time')"
+  query: "WITH d(key, val) AS
+(select key, val from monitor.cgroup_setof_kv('cpu.stat'))
+SELECT
+ (SELECT val FROM d WHERE key='nr_periods') AS nr_periods,
+ (SELECT val FROM d WHERE key='nr_throttled') AS nr_throttled,
+ (SELECT val FROM d WHERE key='throttled_time') AS throttled_time, clock_timestamp() as snap_ts"
   metrics:
-    - nr_threads:
+    - nr_periods:
         usage: "GAUGE"
         description: "number of periods that any thread was runnable"
     - nr_throttled:
@@ -111,7 +139,9 @@ ccp_nodemx_cpustat:
     - throttled_time:
         usage: "GAUGE"
         description: "sum total amount of time individual threads within the monitor.cgroup were throttled"
-
+    - snap_ts:
+        usage: "GAUGE"
+        description: "CPU stat snapshot timestamp"
 
 ccp_nodemx_data_disk:
   query: "SELECT mount_point,fs_type,total_bytes,available_bytes,total_file_nodes,free_file_nodes


### PR DESCRIPTION
The queries that worked against memory.stat and cpu.stat were parsing
the virtual files once per metric rather than once. This causes the
queries to run about 50% slower than they should, and more importantly
means the collected metrics are not atomic snapshots of those values.
Fix that by rewriting the queries to perform the virtual file parsing
once followed by extracting the desired values.

Also add some missing important metrics. In particular,
memory.usage_in_bytes was not being collected.

Additionally grab clock timestamps in the same queries that collect the
cpu usage nanoseconds values. This ensures that the timestamps are
collected as close in time as possible to the cpu usage metrics, such
that some interesting calculations can be made to obtain cpu usage and
throttling percentages.

# Description  

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes (issue) #  

Depends on (issue) #  

## Type of change  
Please check all options that are relevant  
- [ ] Bug fix (change which fixes an issue)  
- [ ] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  

**Tested Configuration**:  
- [ ] CentOS, Specify version(s):  
- [ ] PostgreQL, Specify version(s):  
- [ ] docs tested with hugo <0.60  

Tested with playbook(s):  
# Checklist:  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  

