### PR TITLE
PG Overview data link fix

### DIFF
--- a/grafana/common/PG_Overview.json
+++ b/grafana/common/PG_Overview.json
@@ -31,7 +31,7 @@
             {
               "targetBlank": true,
               "title": "PG Details",
-              "url": "/d/6jtN_vfiz/postgresql-details?$__all_variables"
+              "url": "/d/6jtN_vfiz/postgresql-details?$__all_variables&var-pgcluster=${__field.labels.cluster_name}"
             }
           ],
           "mappings": [
@@ -150,7 +150,7 @@
             {
               "targetBlank": true,
               "title": "PG Details",
-              "url": "/d/6jtN_vfiz/postgresql-details?$__all_variables"
+              "url": "/d/6jtN_vfiz/postgresql-details?$__all_variables&var-pgcluster=${__field.labels.cluster_name}"
             }
           ],
           "mappings": [
@@ -270,7 +270,7 @@
             {
               "targetBlank": true,
               "title": "PG Details",
-              "url": "/d/6jtN_vfiz/postgresql-details?$__all_variables"
+              "url": "/d/6jtN_vfiz/postgresql-details?$__all_variables&var-pgcluster=${__field.labels.cluster_name}"
             }
           ],
           "mappings": [


### PR DESCRIPTION
# Description  

Add missing pgcluster variable to url, this will open correct link in details dashboard.

Fixes (issue) #  

Depends on (issue) #  

## Type of change  
Please check all options that are relevant  
- [x] Bug fix (change which fixes an issue)  
- [ ] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  

**Tested Configuration**:  
- [x] CentOS, Specify version(s):  RHEL8
- [x] PostgreQL, Specify version(s):  10, 11
- [ ] docs tested with hugo <0.60  

Tested with playbook(s):  
# Checklist:  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  

