### PR TITLE
Fix ccp_nodemx_cpucfs Query

### DIFF
--- a/postgres_exporter/common/queries_nodemx.yml
+++ b/postgres_exporter/common/queries_nodemx.yml
@@ -102,7 +102,7 @@ ccp_nodemx_cpu:
 
 ccp_nodemx_cpucfs:
   query: "SELECT  monitor.cgroup_scalar_bigint('cpu.cfs_period_us') as period_us, 
-                  case monitor.cgroup_scalar_bigint('cpu.cfs_quota_us') < 0 then 0 else monitor.cgroup_scalar_bigint('cpu.cfs_quota_us') end as quota_us"
+                  case when monitor.cgroup_scalar_bigint('cpu.cfs_quota_us') < 0 then 0 else monitor.cgroup_scalar_bigint('cpu.cfs_quota_us') end as quota_us"
   metrics:
     - period_us:
         usage: "GAUGE"


### PR DESCRIPTION
Adds a missing "when" to the `ccp_nodemx_cpucfs` query.