### PR TITLE
Change now() to clock_timestamp() in metric queries

### DIFF
--- a/postgres_exporter/common/pg10/queries_general.yml
+++ b/postgres_exporter/common/pg10/queries_general.yml
@@ -11,9 +11,9 @@ ccp_connection_stats:
         , total
         , idle
         , idle_in_txn
-        , (select coalesce(extract(epoch from (max(now() - state_change))),0) from pg_catalog.pg_stat_activity where state = 'idle in transaction') as max_idle_in_txn_time
-        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and state <> 'idle' ) as max_query_time
-        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and wait_event_type = 'Lock' ) as max_blocked_query_time
+        , (select coalesce(extract(epoch from (max(clock_timestamp() - state_change))),0) from pg_catalog.pg_stat_activity where state = 'idle in transaction') as max_idle_in_txn_time
+        , (select coalesce(extract(epoch from (max(clock_timestamp() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and state <> 'idle' ) as max_query_time
+        , (select coalesce(extract(epoch from (max(clock_timestamp() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and wait_event_type = 'Lock' ) as max_blocked_query_time
         , max_connections
         from (
                 select count(*) as total
@@ -51,10 +51,10 @@ ccp_replication_lag:
   query: "SELECT
            CASE
            WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0
-           ELSE EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp())::INTEGER
+           ELSE EXTRACT (EPOCH FROM clock_timestamp() - pg_last_xact_replay_timestamp())::INTEGER
            END
         AS replay_time
-        , EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp())::INTEGER
+        , EXTRACT (EPOCH FROM clock_timestamp() - pg_last_xact_replay_timestamp())::INTEGER
         AS received_time"
   metrics:
     - replay_time:

--- a/postgres_exporter/common/pg11/queries_general.yml
+++ b/postgres_exporter/common/pg11/queries_general.yml
@@ -11,9 +11,9 @@ ccp_connection_stats:
         , total
         , idle
         , idle_in_txn
-        , (select coalesce(extract(epoch from (max(now() - state_change))),0) from pg_catalog.pg_stat_activity where state = 'idle in transaction') as max_idle_in_txn_time
-        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and state <> 'idle' ) as max_query_time
-        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and wait_event_type = 'Lock' ) as max_blocked_query_time
+        , (select coalesce(extract(epoch from (max(clock_timestamp() - state_change))),0) from pg_catalog.pg_stat_activity where state = 'idle in transaction') as max_idle_in_txn_time
+        , (select coalesce(extract(epoch from (max(clock_timestamp() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and state <> 'idle' ) as max_query_time
+        , (select coalesce(extract(epoch from (max(clock_timestamp() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and wait_event_type = 'Lock' ) as max_blocked_query_time
         , max_connections
         from (
                 select count(*) as total
@@ -51,10 +51,10 @@ ccp_replication_lag:
   query: "SELECT
            CASE
            WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0
-           ELSE EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp())::INTEGER
+           ELSE EXTRACT (EPOCH FROM clock_timestamp() - pg_last_xact_replay_timestamp())::INTEGER
            END
         AS replay_time
-        , EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp())::INTEGER
+        , EXTRACT (EPOCH FROM clock_timestamp() - pg_last_xact_replay_timestamp())::INTEGER
         AS received_time"
   metrics:
     - replay_time:

--- a/postgres_exporter/common/pg12/queries_general.yml
+++ b/postgres_exporter/common/pg12/queries_general.yml
@@ -11,9 +11,9 @@ ccp_connection_stats:
         , total
         , idle
         , idle_in_txn
-        , (select coalesce(extract(epoch from (max(now() - state_change))),0) from pg_catalog.pg_stat_activity where state = 'idle in transaction') as max_idle_in_txn_time
-        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and state <> 'idle' ) as max_query_time
-        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and wait_event_type = 'Lock' ) as max_blocked_query_time
+        , (select coalesce(extract(epoch from (max(clock_timestamp() - state_change))),0) from pg_catalog.pg_stat_activity where state = 'idle in transaction') as max_idle_in_txn_time
+        , (select coalesce(extract(epoch from (max(clock_timestamp() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and state <> 'idle' ) as max_query_time
+        , (select coalesce(extract(epoch from (max(clock_timestamp() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and wait_event_type = 'Lock' ) as max_blocked_query_time
         , max_connections
         from (
                 select count(*) as total
@@ -51,10 +51,10 @@ ccp_replication_lag:
   query: "SELECT
            CASE
            WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0
-           ELSE EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp())::INTEGER
+           ELSE EXTRACT (EPOCH FROM clock_timestamp() - pg_last_xact_replay_timestamp())::INTEGER
            END
         AS replay_time
-        , EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp())::INTEGER
+        , EXTRACT (EPOCH FROM clock_timestamp() - pg_last_xact_replay_timestamp())::INTEGER
         AS received_time"
   metrics:
     - replay_time:
@@ -116,7 +116,7 @@ ccp_wal_activity:
 ccp_data_checksum_failure:
   query: "SELECT datname AS dbname
             , checksum_failures AS count
-            , coalesce(extract(epoch from (now() - checksum_last_failure)), 0) AS time_since_last_failure_seconds 
+            , coalesce(extract(epoch from (clock_timestamp() - checksum_last_failure)), 0) AS time_since_last_failure_seconds 
           FROM pg_catalog.pg_stat_database;"
   metrics:
     - dbname:

--- a/postgres_exporter/common/pg13/queries_general.yml
+++ b/postgres_exporter/common/pg13/queries_general.yml
@@ -11,9 +11,9 @@ ccp_connection_stats:
         , total
         , idle
         , idle_in_txn
-        , (select coalesce(extract(epoch from (max(now() - state_change))),0) from pg_catalog.pg_stat_activity where state = 'idle in transaction') as max_idle_in_txn_time
-        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and state <> 'idle' ) as max_query_time
-        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and wait_event_type = 'Lock' ) as max_blocked_query_time
+        , (select coalesce(extract(epoch from (max(clock_timestamp() - state_change))),0) from pg_catalog.pg_stat_activity where state = 'idle in transaction') as max_idle_in_txn_time
+        , (select coalesce(extract(epoch from (max(clock_timestamp() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and state <> 'idle' ) as max_query_time
+        , (select coalesce(extract(epoch from (max(clock_timestamp() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and wait_event_type = 'Lock' ) as max_blocked_query_time
         , max_connections
         from (
                 select count(*) as total
@@ -51,10 +51,10 @@ ccp_replication_lag:
   query: "SELECT
            CASE
            WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0
-           ELSE EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp())::INTEGER
+           ELSE EXTRACT (EPOCH FROM clock_timestamp() - pg_last_xact_replay_timestamp())::INTEGER
            END
         AS replay_time
-        , EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp())::INTEGER
+        , EXTRACT (EPOCH FROM clock_timestamp() - pg_last_xact_replay_timestamp())::INTEGER
         AS received_time"
   metrics:
     - replay_time:
@@ -116,7 +116,7 @@ ccp_wal_activity:
 ccp_data_checksum_failure:
   query: "SELECT datname AS dbname
             , checksum_failures AS count
-            , coalesce(extract(epoch from (now() - checksum_last_failure)), 0) AS time_since_last_failure_seconds
+            , coalesce(extract(epoch from (clock_timestamp() - checksum_last_failure)), 0) AS time_since_last_failure_seconds
           FROM pg_catalog.pg_stat_database;"
   metrics:
     - dbname:

--- a/postgres_exporter/common/pg14/queries_general.yml
+++ b/postgres_exporter/common/pg14/queries_general.yml
@@ -11,9 +11,9 @@ ccp_connection_stats:
         , total
         , idle
         , idle_in_txn
-        , (select coalesce(extract(epoch from (max(now() - state_change))),0) from pg_catalog.pg_stat_activity where state = 'idle in transaction') as max_idle_in_txn_time
-        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and state <> 'idle' ) as max_query_time
-        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and wait_event_type = 'Lock' ) as max_blocked_query_time
+        , (select coalesce(extract(epoch from (max(clock_timestamp() - state_change))),0) from pg_catalog.pg_stat_activity where state = 'idle in transaction') as max_idle_in_txn_time
+        , (select coalesce(extract(epoch from (max(clock_timestamp() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and state <> 'idle' ) as max_query_time
+        , (select coalesce(extract(epoch from (max(clock_timestamp() - query_start))),0) from pg_catalog.pg_stat_activity where backend_type = 'client backend' and wait_event_type = 'Lock' ) as max_blocked_query_time
         , max_connections
         from (
                 select count(*) as total
@@ -51,10 +51,10 @@ ccp_replication_lag:
   query: "SELECT
            CASE
            WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0
-           ELSE EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp())::INTEGER
+           ELSE EXTRACT (EPOCH FROM clock_timestamp() - pg_last_xact_replay_timestamp())::INTEGER
            END
         AS replay_time
-        , EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp())::INTEGER
+        , EXTRACT (EPOCH FROM clock_timestamp() - pg_last_xact_replay_timestamp())::INTEGER
         AS received_time"
   metrics:
     - replay_time:
@@ -116,7 +116,7 @@ ccp_wal_activity:
 ccp_data_checksum_failure:
   query: "SELECT datname AS dbname
             , checksum_failures AS count
-            , coalesce(extract(epoch from (now() - checksum_last_failure)), 0) AS time_since_last_failure_seconds
+            , coalesce(extract(epoch from (clock_timestamp() - checksum_last_failure)), 0) AS time_since_last_failure_seconds
           FROM pg_catalog.pg_stat_database;"
   metrics:
     - dbname:

--- a/postgres_exporter/common/pg96/queries_general.yml
+++ b/postgres_exporter/common/pg96/queries_general.yml
@@ -13,9 +13,9 @@ ccp_connection_stats:
         , total
         , idle
         , idle_in_txn
-        , (select coalesce(extract(epoch from (max(now() - state_change))),0) from monitor.pg_stat_activity() where state = 'idle in transaction') as max_idle_in_txn_time
-        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from monitor.pg_stat_activity() where state <> 'idle') as max_query_time
-        , (select coalesce(extract(epoch from (max(now() - query_start))),0) from pg_catalog.pg_stat_activity where wait_event_type = 'Lock' ) as max_blocked_query_time
+        , (select coalesce(extract(epoch from (max(clock_timestamp() - state_change))),0) from monitor.pg_stat_activity() where state = 'idle in transaction') as max_idle_in_txn_time
+        , (select coalesce(extract(epoch from (max(clock_timestamp() - query_start))),0) from monitor.pg_stat_activity() where state <> 'idle') as max_query_time
+        , (select coalesce(extract(epoch from (max(clock_timestamp() - query_start))),0) from pg_catalog.pg_stat_activity where wait_event_type = 'Lock' ) as max_blocked_query_time
         , max_connections
         from (
                 select count(*) as total
@@ -53,10 +53,10 @@ ccp_replication_lag:
   query: "SELECT
            CASE
            WHEN pg_last_xlog_receive_location() = pg_last_xlog_replay_location() THEN 0
-           ELSE EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp())::INTEGER
+           ELSE EXTRACT (EPOCH FROM clock_timestamp() - pg_last_xact_replay_timestamp())::INTEGER
            END
         AS replay_time
-        , EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp())::INTEGER
+        , EXTRACT (EPOCH FROM clock_timestamp() - pg_last_xact_replay_timestamp())::INTEGER
         AS received_time"
   metrics:
     - replay_time:

--- a/postgres_exporter/common/queries_global.yml
+++ b/postgres_exporter/common/queries_global.yml
@@ -220,7 +220,7 @@ ccp_sequence_exhaustion:
 
 
 ccp_postmaster_uptime:
-    query: "SELECT extract(epoch from (now() - pg_postmaster_start_time() )) AS seconds;"
+    query: "SELECT extract(epoch from (clock_timestamp() - pg_postmaster_start_time() )) AS seconds;"
     metrics:
         - seconds:
             usage: "GAUGE"


### PR DESCRIPTION
# Description  

Change queries using now() to clock_timestamp(). If a query runs a little longer than expected, it could potentially result in negative values when doing math with time due to now() being the time at the beginning of the transaction vs a time value being returned when the query finally runs.

Fixes #237 

## Type of change  
Please check all options that are relevant  
- [x] Bug fix (change which fixes an issue)  
- [ ] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  
**Tested Configuration**:  
- [x] Ansible, Specify version(s):  2.9
- Installation method:  
    - [ ] Binary install from source, version: 
    - [x] OS package repository, distro, and version:  CentOS7
    - [x] Local package server, version:  4.5
    - [ ] Custom-built package, version:  
    - [ ] Other:  
- [x] PostgreSQL, Specify version(s):  13
- [ ] docs tested with hugo version(s):  

Tested with playbook(s):  

# Checklist:  
- [x] My changes generate no new lint warnings  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  
