### PR TITLE
add disk usage condition to DiskFillPredict alert and PGClusterRoleChange alert

### DIFF
--- a/prometheus/containers/alert-rules.d/crunchy-alert-rules-pg.yml.containers.example
+++ b/prometheus/containers/alert-rules.d/crunchy-alert-rules-pg.yml.containers.example
@@ -183,6 +183,27 @@ groups:
       description: '{{ $labels.job }} is using 90% or more of available connections ({{ $value }}%)'
       summary: 'PGSQL Instance connections'
 
+  - alert: DiskFillPredict
+    expr: predict_linear(ccp_nodemx_data_disk_available_bytes{mount_point!~"tmpfs"}[1h], 24 * 3600) < 0 and 100 * ((ccp_nodemx_data_disk_total_bytes - ccp_nodemx_data_disk_available_bytes) / ccp_nodemx_data_disk_total_bytes) > 70
+    for: 5m
+    labels:
+      service: postgresql
+      severity: warning
+      severity_num: 200
+    annotations:
+      summary: 'Disk predicted to be full in 24 hours'
+      description: 'Disk on {{ $labels.pg_cluster }}:{{ $labels.kubernetes_pod_name }} is predicted to fill in 24 hrs based on current usage'
+
+  - alert: PGClusterRoleChange
+    expr: count by (pg_cluster) (ccp_is_in_recovery_status != ignoring(instance,ip,pod,role) (ccp_is_in_recovery_status offset 5m)) >= 1
+    for: 60s
+    labels:
+      service: postgresql
+      severity: critical
+      severity_num: 300
+    annotations:
+      summary: '{{ $labels.pg_cluster }} has had a switchover/failover event. Please check this cluster for more details'
+
   - alert: PGDiskSize
     expr: 100 * ((ccp_nodemx_data_disk_total_bytes - ccp_nodemx_data_disk_available_bytes) / ccp_nodemx_data_disk_total_bytes) > 75
     for: 60s


### PR DESCRIPTION
# Description  
1. DiskFillPredict alert was generating false alerts during ETL jobs especially on smaller-sized disks. So, I have added a disk usage condition to reduce the false alerts. This alert is very similar to the PGDiskUsage alert. But, works better regardless of the disk size. 
2. PGClusterRoleChange: This alert is to inform the users that there was a switchover/failover event on a particular PostgreSQL cluster. This is a generic alert that does not depend on a specific job or cluster like PGRecoveryStatusSwitch_Replica. So, users do not have to configure an alert for each cluster.

Fixes #  

Depends on #  

## Type of change  
Please check all options that are relevant  
- [ ] Bug fix (change which fixes an issue)  
- [X ] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  
Yes. Tested on openshift cluster 4.6


# Checklist:  
- [ ] My changes generate no new lint warnings  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  
