### PR TITLE
Fix primary mapping value in pg overview dashboard for grafana 8+

### DIFF
--- a/grafana/common/PG_Overview.json
+++ b/grafana/common/PG_Overview.json
@@ -15,7 +15,8 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1617294517997,
+  "id": 13,
+  "iteration": 1640878867114,
   "links": [],
   "panels": [
     {
@@ -26,7 +27,6 @@
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "links": [
             {
               "targetBlank": true,
@@ -47,7 +47,7 @@
               "op": "=",
               "text": "PRIMARY",
               "type": 1,
-              "value": ".5"
+              "value": "0.5"
             },
             {
               "id": 2,
@@ -112,14 +112,14 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "7.5.12",
       "repeat": "pgnodes",
       "repeatDirection": "h",
       "scopedVars": {
         "pgnodes": {
           "selected": false,
-          "text": "alpha_ip16_pg1",
-          "value": "alpha_ip16_pg1"
+          "text": "golf_ip16_pg1",
+          "value": "golf_ip16_pg1"
         }
       },
       "targets": [
@@ -145,7 +145,6 @@
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "links": [
             {
               "targetBlank": true,
@@ -231,15 +230,15 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "7.5.12",
       "repeatDirection": "h",
-      "repeatIteration": 1617294517997,
+      "repeatIteration": 1640878867114,
       "repeatPanelId": 1,
       "scopedVars": {
         "pgnodes": {
           "selected": false,
-          "text": "alpha_ip26_pg2",
-          "value": "alpha_ip26_pg2"
+          "text": "golf_ip26_pg2",
+          "value": "golf_ip26_pg2"
         }
       },
       "targets": [
@@ -265,7 +264,6 @@
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "links": [
             {
               "targetBlank": true,
@@ -351,15 +349,15 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "7.5.12",
       "repeatDirection": "h",
-      "repeatIteration": 1617294517997,
+      "repeatIteration": 1640878867114,
       "repeatPanelId": 1,
       "scopedVars": {
         "pgnodes": {
           "selected": false,
-          "text": "alpha_ip36_pg3",
-          "value": "alpha_ip36_pg3"
+          "text": "golf_ip36_pg3",
+          "value": "golf_ip36_pg3"
         }
       },
       "targets": [
@@ -441,5 +439,5 @@
   "timezone": "browser",
   "title": "PostgreSQL Overview",
   "uid": "pxinDnNik",
-  "version": 2
+  "version": 1
 }

--- a/grafana/common/PG_Overview.json
+++ b/grafana/common/PG_Overview.json
@@ -15,8 +15,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 13,
-  "iteration": 1640878867114,
+  "iteration": 1617294517997,
   "links": [],
   "panels": [
     {
@@ -27,6 +26,7 @@
           "color": {
             "mode": "thresholds"
           },
+          "custom": {},
           "links": [
             {
               "targetBlank": true,
@@ -112,14 +112,14 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.12",
+      "pluginVersion": "7.4.5",
       "repeat": "pgnodes",
       "repeatDirection": "h",
       "scopedVars": {
         "pgnodes": {
           "selected": false,
-          "text": "golf_ip16_pg1",
-          "value": "golf_ip16_pg1"
+          "text": "alpha_ip16_pg1",
+          "value": "alpha_ip16_pg1"
         }
       },
       "targets": [
@@ -145,6 +145,7 @@
           "color": {
             "mode": "thresholds"
           },
+          "custom": {},
           "links": [
             {
               "targetBlank": true,
@@ -165,7 +166,7 @@
               "op": "=",
               "text": "PRIMARY",
               "type": 1,
-              "value": ".5"
+              "value": "0.5"
             },
             {
               "id": 2,
@@ -230,15 +231,15 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.12",
+      "pluginVersion": "7.4.5",
       "repeatDirection": "h",
-      "repeatIteration": 1640878867114,
+      "repeatIteration": 1617294517997,
       "repeatPanelId": 1,
       "scopedVars": {
         "pgnodes": {
           "selected": false,
-          "text": "golf_ip26_pg2",
-          "value": "golf_ip26_pg2"
+          "text": "alpha_ip26_pg2",
+          "value": "alpha_ip26_pg2"
         }
       },
       "targets": [
@@ -264,6 +265,7 @@
           "color": {
             "mode": "thresholds"
           },
+          "custom": {},
           "links": [
             {
               "targetBlank": true,
@@ -284,7 +286,7 @@
               "op": "=",
               "text": "PRIMARY",
               "type": 1,
-              "value": ".5"
+              "value": "0.5"
             },
             {
               "id": 2,
@@ -349,15 +351,15 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.12",
+      "pluginVersion": "7.4.5",
       "repeatDirection": "h",
-      "repeatIteration": 1640878867114,
+      "repeatIteration": 1617294517997,
       "repeatPanelId": 1,
       "scopedVars": {
         "pgnodes": {
           "selected": false,
-          "text": "golf_ip36_pg3",
-          "value": "golf_ip36_pg3"
+          "text": "alpha_ip36_pg3",
+          "value": "alpha_ip36_pg3"
         }
       },
       "targets": [
@@ -439,5 +441,5 @@
   "timezone": "browser",
   "title": "PostgreSQL Overview",
   "uid": "pxinDnNik",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
# Description  

Fix issue with Grafana 8+ not accepting decimal values that are not prepended with a zero as valid mapping values. Tested and adding the prepended zero works for Grafana 7.5 without any issues.

Fixes #265

## Type of change  
Please check all options that are relevant  
- [x] Bug fix (change which fixes an issue)  
- [ ] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  
**Tested Configuration**:  
- [x] Ansible, Specify version(s):  2.9
- Installation method:  
    - [ ] Binary install from source, version:  
    - [x] OS package repository, distro, and version:  CentOS7
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [ ] Other:  
- [x] PostgreSQL, Specify version(s):  14
- [ ] docs tested with hugo version(s):  

Tested with playbook(s):  

# Checklist:  
- [x] My changes generate no new lint warnings  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  
