### PR TITLE
Fix Grafana filesystem panel consistency

### DIFF
--- a/grafana/linux/OS_Details.json
+++ b/grafana/linux/OS_Details.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
   "iteration": 1618265425340,
@@ -710,7 +710,7 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "100 - 100 * sum(node_filesystem_avail_bytes{device!~\"tmpfs|by-uuid\",fstype=~\"xfs|ext[234]\", job=~\"[[osnodes]]\"} / node_filesystem_size_bytes{device!~\"tmpfs|by-uuid\",fstype=~\"xfs|ext[234]\", job=~\"[[osnodes]]\"}) BY (job,device,mountpoint)",
+          "expr": "100 - 100 * sum(node_filesystem_free_bytes{job=~\"[[osnodes]]\", fstype!~\".*tmpfs.*|.*root.*|.*pipe.*\"} / node_filesystem_size_bytes{job=~\"[[osnodes]]\", fstype!~\".*tmpfs.*|.*root.*|.*pipe.*\"}) BY (job,device,mountpoint)",
           "interval": "",
           "legendFormat": "{{mountpoint}}",
           "refId": "A"


### PR DESCRIPTION
# Description  

As reported, the left small panel in the OS Details for the file system list not consistent with the other panels. Fixes this as well as marking the dashboard as read-only. 

Fixes #286 

## Type of change  
Please check all options that are relevant  
- [x] Bug fix (change which fixes an issue)  
- [ ] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  
**Tested Configuration**:  
- [x] Ansible, Specify version(s):  2.9
- Installation method:  
    - [ ] Binary install from source, version:  
    - [x] OS package repository, distro, and version:  RHEL8, pgMonitor 4.6-1
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [ ] Other:  
- [ ] PostgreSQL, Specify version(s):  
- [ ] docs tested with hugo version(s):  

Tested with playbook(s):  

# Checklist:  
- [ ] My changes generate no new lint warnings  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  
