### PR TITLE
Update deprecated storage path variable in prometheus sysconfig

### DIFF
--- a/changelogs/fragments/293.md
+++ b/changelogs/fragments/293.md
@@ -1,0 +1,2 @@
+minor_changes:
+- sysconfig - update prometheus sysconfig file to use up to date startup values (https://github.com/CrunchyData/pgmonitor/issues/293)

--- a/changelogs/fragments/293.md
+++ b/changelogs/fragments/293.md
@@ -1,2 +1,2 @@
 minor_changes:
-- sysconfig - update prometheus sysconfig file to use up to date startup values (https://github.com/CrunchyData/pgmonitor/issues/293)
+- prometheus - update prometheus sysconfig file to use up to date startup values (https://github.com/CrunchyData/pgmonitor/issues/293)

--- a/prometheus/linux/sysconfig.prometheus
+++ b/prometheus/linux/sysconfig.prometheus
@@ -12,4 +12,4 @@
 # --log.level: how verbose to make system logging. Setting to "debug" can help with diagnosing issues, but should not be left that way.
 # --web.enable-admin-api: set this to make the admin api available which allows database snaphot backups. Left off by default for security.
 
-OPT="--config.file=/etc/prometheus/crunchy-prometheus.yml --storage.tsdb.path=/var/lib/ccp_monitoring/prometheus --storage.tsdb.retention=168h --log.level=info"
+OPT="--config.file=/etc/prometheus/crunchy-prometheus.yml --storage.tsdb.path=/var/lib/ccp_monitoring/prometheus --storage.tsdb.retention.time=7d --log.level=info"


### PR DESCRIPTION
# Description  

Update the sysconfig file for Prometheus to use non-deprecated value for tsdb storage. Change to clearer `7d` value for retention. Reviewed other options in use by default for prometheus and alertmanager sysconfig and all look fine so far.

Fixes #293 


## Type of change  
Please check all options that are relevant  
- [x] Bug fix (change which fixes an issue)  
- [ ] Feature (change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update only  

# How Has This Been Tested?  
**Tested Configuration**:  
- [ ] Ansible, Specify version(s):  
- Installation method:  
    - [ ] Binary install from source, version:  
    - [ ] OS package repository, distro, and version:  
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [ ] Other:  
- [ ] PostgreSQL, Specify version(s):  
- [ ] docs tested with hugo version(s):  

Tested with playbook(s):  

# Checklist:  
- [ ] My changes generate no new lint warnings  
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  
