### PR TITLE
Remove redundant labels from prometheus scrape

### DIFF
--- a/prometheus/containers/crunchy-prometheus.yml.containers
+++ b/prometheus/containers/crunchy-prometheus.yml.containers
@@ -53,15 +53,6 @@ scrape_configs:
     target_label: role
     replacement: '$1'
     separator: ""
-  - source_labels: [dbname]
-    target_label: dbname
-    replacement: '$1'
-  - source_labels: [relname]
-    target_label: relname
-    replacement: '$1'
-  - source_labels: [schemaname]
-    target_label: schemaname
-    replacement: '$1'
 
 rule_files:
   - /etc/prometheus/alert-rules.d/*.yml


### PR DESCRIPTION
# Description  

The prometheus scrape_configs included some relabeling actions that seemed like no-ops -- renaming labels to themselves. This PR removes them, but also may be an opportunity to discuss why they were there in case I'm missing something.

I've tested this manually by checking certain metrics with those labels before / after removing them from the scrape configs.