### PR TITLE
Load by cpu count

### DIFF
--- a/changelogs/fragments/120.yml
+++ b/changelogs/fragments/120.yml
@@ -1,0 +1,2 @@
+minor_change:
+  - prometheus - Allow node_exporter's load alert to be based on the CPU count. Allows lowering of default thresholds and more accurate alerting.

--- a/prometheus/linux/alert-rules.d/crunchy-alert-rules-node.yml.example
+++ b/prometheus/linux/alert-rules.d/crunchy-alert-rules-node.yml.example
@@ -53,24 +53,24 @@ groups:
       description: 'Disk usage on target {{ $labels.job }} at {{ $value }}%'
 
   - alert: SystemLoad5m
-    expr: node_load5 > 5
+    expr: node_load5 > (count(count(node_cpu_seconds_total) without (mode)) without (cpu)) * 2
     for: 10m
     labels:
       service: system
       severity: warning
       severity_num: 200
     annotations:
-      description: 'System load for target {{ $labels.job }} is high ({{ $value }})'
+      description: 'System load for target {{ $labels.job }} is high ({{ $value }}) based on cpu count'
 
   - alert: SystemLoad5m
-    expr: node_load5 > 10
+    expr: node_load5 > (count(count(node_cpu_seconds_total) without (mode)) without (cpu)) * 4
     for: 10m
     labels:
       service: system
       severity: critical
       severity_num: 300
     annotations:
-      description: 'System load for target {{ $labels.job }} is high ({{ $value }})'
+      description: 'System load for target {{ $labels.job }} is high ({{ $value }}) based on cpu count'
 
   - alert: MemoryAvailable
     expr: (100 * (node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes) < 25


### PR DESCRIPTION
# Description  

Allow node_exporter alerting for load to be based on CPU count. Allows lowering of default threshold and more accurate alerting.

Please indicate what kind of change your PR includes (multiple selections are acceptable):

- [ ] Bugfix
- [x] Enhancement
- [ ] Breaking Change
- [ ] Documentation

PRs should be against existing issues, so please list each issue using a separate 'closes' line:

closes #120 


## Testing
*None of the testing listed below is optional.*

- Installation method:  
    - [ ] Binary install from source, version:  
    - [x] OS package repository, distro, and version:  
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [ ] Other:  
- [x] PostgreSQL, Specify version(s):  15
- [ ] docs tested with hugo version(s):  

### Code testing

Have you tested your changes against:
- [x] RedHat/CentOS
- [ ] Ubuntu
- [ ] SLES
- [ ] Not applicable

If your code touches postgres_exporter, have you:
- [ ] Tested against all versions of PostgreSQL affected
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches node_exporter, have you:
- [x] Ensure that exporter runs with no scrape errors
- [ ] Not applicable

If your code touches Prometheus, have you:
- [x] Ensured all configuration changes pass `promtool check config`
- [x] Ensured all alert rule changes pass `promtool check rules`
- [x] Prometheus runs without issue
- [x] Alertmanager runs without issue
- [ ] Not applicable

If your code touches Grafana, have you:
- [ ] Ensured Grafana runs without issue
- [ ] Ensured relevant dashboards load without issue
- [x] Not applicable

### Checklist:
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [x] the release notes  
    - [ ] the upgrade doc  
