### PR TITLE
Improve system catalog query

### DIFF
--- a/pgbadger/run_pgbadger.py
+++ b/pgbadger/run_pgbadger.py
@@ -26,7 +26,7 @@ args = parser.parse_args()
 
 if not os.path.exists(args.output):
     print "Path given by --output (-o) does not exist: " + str(args.output)
-    sys.exit(2)	
+    sys.exit(2)
 
 def get_databases():
     conn = psycopg2.connect(args.connection)
@@ -124,8 +124,8 @@ if __name__ == "__main__":
         call_pgbadger += " -j " + str(args.jobs)
         call_pgbadger += " -J " + str(args.Jobs)
         call_pgbadger += " -p \"" + args.log_line_prefix + "\""
-	if args.exclude_query is not None:
-	    call_pgbadger += " --exclude-query=\"" + args.exclude_query + "\""
+        if args.exclude_query is not None:
+            call_pgbadger += " --exclude-query=\"" + args.exclude_query + "\""
         if args.verbose == True:
             print call_pgbadger 
         os.system(call_pgbadger)

--- a/postgres_exporter/common/queries_global.yml
+++ b/postgres_exporter/common/queries_global.yml
@@ -35,23 +35,23 @@ ccp_database_size:
 
 ccp_locks:
     query: "SELECT pg_database.datname as dbname, tmp.mode, COALESCE(count,0) as count
-			FROM
-				(
-				  VALUES ('accesssharelock'),
-				         ('rowsharelock'),
-				         ('rowexclusivelock'),
-				         ('shareupdateexclusivelock'),
-				         ('sharelock'),
-				         ('sharerowexclusivelock'),
-				         ('exclusivelock'),
-				         ('accessexclusivelock')
-				) AS tmp(mode) CROSS JOIN pg_catalog.pg_database
-			LEFT JOIN
-			  (SELECT database, lower(mode) AS mode,count(*) AS count
-			  FROM pg_catalog.pg_locks WHERE database IS NOT NULL
-			  GROUP BY database, lower(mode)
-			) AS tmp2
-			ON tmp.mode=tmp2.mode and pg_database.oid = tmp2.database"
+                        FROM
+                                (
+                                  VALUES ('accesssharelock'),
+                                         ('rowsharelock'),
+                                         ('rowexclusivelock'),
+                                         ('shareupdateexclusivelock'),
+                                         ('sharelock'),
+                                         ('sharerowexclusivelock'),
+                                         ('exclusivelock'),
+                                         ('accessexclusivelock')
+                                ) AS tmp(mode) CROSS JOIN pg_catalog.pg_database
+                        LEFT JOIN
+                          (SELECT database, lower(mode) AS mode,count(*) AS count
+                          FROM pg_catalog.pg_locks WHERE database IS NOT NULL
+                          GROUP BY database, lower(mode)
+                        ) AS tmp2
+                        ON tmp.mode=tmp2.mode and pg_database.oid = tmp2.database"
     metrics:
         - dbname:
             usage: "LABEL"

--- a/postgres_exporter/common/queries_per_db.yml
+++ b/postgres_exporter/common/queries_per_db.yml
@@ -63,7 +63,7 @@ ccp_stat_user_tables:
 
 
 ccp_table_size:
-  query: "SELECT current_database() as dbname, n.nspname as schemaname, c.relname, pg_total_relation_size(c.oid) as size_bytes FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid WHERE NOT pg_is_other_temp_schema(n.oid) AND relkind IN ('r', 'm', 'f')"
+  query: "SELECT current_database() as dbname, c.relnamespace::regnamespace as schemaname, c.relname, pg_total_relation_size(c.oid) as size_bytes FROM pg_catalog.pg_class WHERE NOT pg_is_other_temp_schema(c.relnamespace) AND relkind IN ('r', 'm', 'f')"
   metrics:
     - dbname:
         usage: "LABEL"

--- a/postgres_exporter/common/queries_per_db.yml
+++ b/postgres_exporter/common/queries_per_db.yml
@@ -63,7 +63,7 @@ ccp_stat_user_tables:
 
 
 ccp_table_size:
-  query: "SELECT current_database() as dbname, c.relnamespace::regnamespace as schemaname, c.relname, pg_total_relation_size(c.oid) as size_bytes FROM pg_catalog.pg_class WHERE NOT pg_is_other_temp_schema(c.relnamespace) AND relkind IN ('r', 'm', 'f')"
+  query: "SELECT current_database() as dbname, relnamespace::regnamespace as schemaname, relname, pg_total_relation_size(oid) as size_bytes FROM pg_class WHERE NOT pg_is_other_temp_schema(relnamespace) AND relkind IN ('r', 'm', 'f')"
   metrics:
     - dbname:
         usage: "LABEL"

--- a/postgres_exporter/windows/queries_common.yml
+++ b/postgres_exporter/windows/queries_common.yml
@@ -22,23 +22,23 @@ ccp_is_in_recovery:
 
 ccp_locks:
     query: "SELECT pg_database.datname as dbname, tmp.mode, COALESCE(count,0) as count
-			FROM
-				(
-				  VALUES ('accesssharelock'),
-				         ('rowsharelock'),
-				         ('rowexclusivelock'),
-				         ('shareupdateexclusivelock'),
-				         ('sharelock'),
-				         ('sharerowexclusivelock'),
-				         ('exclusivelock'),
-				         ('accessexclusivelock')
-				) AS tmp(mode) CROSS JOIN pg_catalog.pg_database
-			LEFT JOIN
-			  (SELECT database, lower(mode) AS mode,count(*) AS count
-			  FROM pg_catalog.pg_locks WHERE database IS NOT NULL
-			  GROUP BY database, lower(mode)
-			) AS tmp2
-			ON tmp.mode=tmp2.mode and pg_database.oid = tmp2.database"
+                        FROM
+                                (
+                                  VALUES ('accesssharelock'),
+                                         ('rowsharelock'),
+                                         ('rowexclusivelock'),
+                                         ('shareupdateexclusivelock'),
+                                         ('sharelock'),
+                                         ('sharerowexclusivelock'),
+                                         ('exclusivelock'),
+                                         ('accessexclusivelock')
+                                ) AS tmp(mode) CROSS JOIN pg_catalog.pg_database
+                        LEFT JOIN
+                          (SELECT database, lower(mode) AS mode,count(*) AS count
+                          FROM pg_catalog.pg_locks WHERE database IS NOT NULL
+                          GROUP BY database, lower(mode)
+                        ) AS tmp2
+                        ON tmp.mode=tmp2.mode and pg_database.oid = tmp2.database"
     metrics:
         - dbname:
             usage: "LABEL"


### PR DESCRIPTION
Query can be very slow, so remove the pg_namespace join. The original can be slow for pathologically bloated schemas with thousands of relations.

# Description  

Change query from using a join on pg_namespace to using a cast to regnamespace instead. Requires Postgres 9.5 or later.


Please indicate what kind of change your PR includes (multiple selections are acceptable):

- [* ] Enhancement

PRs should be against existing issues, so please list each issue using a separate 'closes' line:

closes #325 
