### PR TITLE
feat: enable datachecksum alert by default supported versions

### DIFF
--- a/changelogs/fragments/330.yml
+++ b/changelogs/fragments/330.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - prometheus - Enable the PGDataChecksum alert by default for PG12+

--- a/prometheus/common/alert-rules.d/crunchy-alert-rules-pg.yml.example
+++ b/prometheus/common/alert-rules.d/crunchy-alert-rules-pg.yml.example
@@ -104,16 +104,17 @@ groups:
 
 
 ## Monitor for data block checksum failures. Only works in PG12+
-#  - alert: PGDataChecksum
-#    expr: ccp_data_checksum_failure_count > 0
-#    for 60s
-#    labels:
-#      service: postgresql
-#      severity: critical
-#      severity_num: 300
-#    annotations:
-#      description: '{{ $labels.job }} has at least one data checksum failure in database {{ $labels.dbname }}. See pg_stat_database system catalog for more information.'
-#      summary: 'PGSQL Data Checksum failure'
+  - alert: PGDataChecksum
+    expr: ccp_postgresql_version_current >= 120000 and ccp_data_checksum_failure_count > 0
+    for: 60s
+    labels:
+      service: postgresql
+      severity: critical
+      severity_num: 300
+    annotations:
+      description: '{{ $labels.job }} has at least one data checksum failure in database {{ $labels.dbname }}. See pg_stat_database system catalog for more information.'
+      summary: 'PGSQL Data Checksum failure'
+
 
   - alert: PGIdleTxn
     expr: ccp_connection_stats_max_idle_in_txn_time > 300


### PR DESCRIPTION
# Description  

Enable the data checksum alert by default for PG12 and above.

Please indicate what kind of change your PR includes (multiple selections are acceptable):

- [ ] Bugfix
- [x] Enhancement
- [ ] Breaking Change
- [ ] Documentation

PRs should be against existing issues, so please list each issue using a separate 'closes' line:

closes #330 


## Testing
*None of the testing listed below is optional.*

- Installation method:  
    - [ ] Binary install from source, version:  
    - [x] OS package repository, distro, and version:  Crunchy HA 1.15
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [ ] Other:  
- [x] PostgreSQL, Specify version(s):  11 & 12
- [ ] docs tested with hugo version(s):  

### Code testing

Have you tested your changes against:
- [x] RedHat/CentOS
- [ ] Ubuntu
- [ ] SLES
- [ ] Not applicable

If your code touches postgres_exporter, have you:
- [ ] Tested against all versions of PostgreSQL affected
- [ ] Ensure that exporter runs with no scrape errors
- [ ] Not applicable

If your code touches node_exporter, have you:
- [ ] Ensure that exporter runs with no scrape errors
- [ ] Not applicable

If your code touches Prometheus, have you:
- [ ] Ensured all configuration changes pass `promtool check config`
- [x] Ensured all alert rule changes pass `promtool check rules`
- [x] Prometheus runs without issue
- [ ] Alertmanager runs without issue
- [ ] Not applicable

If your code touches Grafana, have you:
- [ ] Ensured Grafana runs without issue
- [ ] Ensured relevant dashboards load without issue
- [x] Not applicable

### Checklist:
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [x] the release notes  
    - [ ] the upgrade doc  
