### PR TITLE
Update dashboard links to use supported endpoints using the dashboard…

### DIFF
--- a/changelogs/fragments/338.yml
+++ b/changelogs/fragments/338.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - grafana - fixed dashboard links that broke when Grafana removed support for the `/dashboard/db/:slug` endpoint in v8

--- a/grafana/containers/postgresql_details.json
+++ b/grafana/containers/postgresql_details.json
@@ -85,7 +85,7 @@
           "links": [
             {
               "title": "pgBackrest",
-              "url": "/dashboard/db/pgbackrest?${__all_variables}"
+              "url": "/d/2fcFZ6PGk/pgbackrest?${__all_variables}"
             }
           ],
           "mappings": [
@@ -129,7 +129,7 @@
       "links": [
         {
           "title": "pgBackRest",
-          "url": "/dashboard/db/pgbackrest?${__all_variables}"
+          "url": "/d/2fcFZ6PGk/pgbackrest?${__all_variables}"
         }
       ],
       "maxDataPoints": 100,

--- a/grafana/containers/postgresql_overview.json
+++ b/grafana/containers/postgresql_overview.json
@@ -62,27 +62,27 @@
             {
               "targetBlank": true,
               "title": "Cluster Details",
-              "url": "dashboard/db/postgresqldetails?$__all_variables"
+              "url": "d/fMip0cuMk/postgresqldetails?$__all_variables"
             },
             {
               "targetBlank": true,
               "title": "Backup Details",
-              "url": "dashboard/db/pgbackrest?$__all_variables"
+              "url": "d/2fcFZ6PGk/pgbackrest?$__all_variables"
             },
             {
               "targetBlank": true,
               "title": "POD Details",
-              "url": "dashboard/db/pod-details?$__all_variables"
+              "url": "d/4auP6Mk7k/pod-details?$__all_variables"
             },
             {
               "targetBlank": true,
               "title": "Query Statistics",
-              "url": "dashboard/db/query-statistics?$__all_variables"
+              "url": "d/ZKoTOHDGk/query-statistics?$__all_variables"
             },
             {
               "targetBlank": true,
               "title": "Service Health",
-              "url": "dashboard/db/postgresql-service-health?$__all_variables"
+              "url": "d/dhG1wgsMz/postgresql-service-health?$__all_variables"
             }
           ],
           "mappings": [


### PR DESCRIPTION
Pull grafana changes from PR #338  into v4.8 stable to allow release of 4.8.1

