### PR TITLE
added alert rule for no primary

### DIFF
--- a/prometheus/common/alert-rules.d/crunchy-alert-rules-pg.yml.example
+++ b/prometheus/common/alert-rules.d/crunchy-alert-rules-pg.yml.example
@@ -31,6 +31,15 @@ groups:
     annotations:
       summary: 'postgres_exporter running on {{ $labels.job }} is unable to communicate with the configured database'
 
+  - alert: NoPrimary
+    expr: max by (cluster_name) (ccp_is_in_recovery_status) < 2
+    for: 30s
+    labels:
+      service: postgresql
+      severity: critical
+      severity_num: 300
+    annotations:
+      summary: 'cluster {{ $labels.cluster_name }} does not have a primary instance'
 
 ## Example to check for current version of PostgreSQL. Metric returns the version that the exporter is running on, so you can set a rule to check for the minimum version you'd like all systems to be on. Number returned is the 6 digit integer representation contained in the setting "server_version_num".
 #


### PR DESCRIPTION
# Description  

*Please fill this template out fully; failure to do so can result in rejection of your PR.*

Please describe the changes made by your PR. This description should be at a high-level but detailed enough that a reviewer understands the scope of the fix or enhancement and can easily judge the PRs validity at addressing the stated issue/feature. Please fully describe any new or changed feature and whether said change is user-facing or not:

Add alert for cases where a Postgres HA cluster does not have an instance that is the leader/primary.

Please indicate what kind of change your PR includes (multiple selections are acceptable):

- [ ] Bugfix
- [X] Enhancement
- [ ] Breaking Change
- [ ] Documentation

PRs should be against existing issues, so please list each issue using a separate 'closes' line:

closes #

If this PR depends on another PR or resolution of another issue, please indicate that here using a separate 'depends' line for each dependency.

depends on #

If you have an **external** dependency (packages, portal updates, etc), add the 'BLOCKED' tag to your PR.


## Testing
*None of the testing listed below is optional.*

- Installation method:  
    - [ ] Binary install from source, version:  
    - [X] OS package repository, distro, and version:  
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [ ] Other:  
- [ ] PostgreSQL, Specify version(s):  14
- [ ] docs tested with hugo version(s):  

### Code testing

Have you tested your changes against:
- [X] RedHat/CentOS
- [ ] Ubuntu
- [ ] SLES
- [ ] Not applicable

If your code touches postgres_exporter, have you:
- [ ] Tested against all versions of PostgreSQL affected
- [ ] Ensure that exporter runs with no scrape errors
- [X] Not applicable

If your code touches node_exporter, have you:
- [ ] Ensure that exporter runs with no scrape errors
- [X] Not applicable

If your code touches Prometheus, have you:
- [ ] Ensured all configuration changes pass `promtool check config`
- [ ] Ensured all alert rule changes pass `promtool check rules`
- [X] Prometheus runs without issue
- [ ] Alertmanager runs without issue
- [ ] Not applicable

If your code touches Grafana, have you:
- [ ] Ensured Grafana runs without issue
- [ ] Ensured relevant dashboards load without issue
- [X] Not applicable

### Checklist:
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  
