### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,9 +8,3 @@
 # team will be added for review when someone opens a pull request.
 
 * @hunleyd @jchancojr @keithf4 @pgguru
-
-# The @crunchydata/build-release owns any files in the build
-# directory at the root of the repository and any of its
-# subdirectories.
-
-/build/ @crunchydata/build-release


### PR DESCRIPTION
No longer needed since we'll be using Linear BUR issues to track changes in the packaging