### PR TITLE
feat: add support for new alertmanager interfaces in grafana

### DIFF
--- a/changelogs/fragments/250.yml
+++ b/changelogs/fragments/250.yml
@@ -1,0 +1,3 @@
+major_changes:
+  - grafana - add alertmanager datasource to grafana to allow direct alert management via grafana
+  - grafana - update Prometheus Alerts dashboard to include new alert panel interface for active alerts  

--- a/changelogs/fragments/template.yml.example
+++ b/changelogs/fragments/template.yml.example
@@ -1,0 +1,27 @@
+---
+breaking_changes:
+  - area affected (roles, specific role, playbooks, docs) - This category should list all changes to features which absolutely require attention from users when upgrading, because an existing behavior is changed. This section should only appear in a initial major release (`x.0.0`) according to semantic versioning.
+
+major_changes:
+  - area affected (roles, specific role, playbooks, docs) - This category contains major changes to the project. It should only contain a few items per major version, describing high-level changes. This section should not appear in patch releases according to semantic versioning.
+
+minor_changes:
+  - area affected (roles, specific role, playbooks, docs) - This category should mention all new features not contained elsewhere. This section should not appear in patch releases according to semantic versioning.
+
+removed_features:
+  - area affected (roles, specific role, playbooks, docs) - This category should mention all features that have been removed in this release. This section should only appear in a initial major release (`x.0.0`) according to semantic versioning.
+
+deprecated_features:
+  - area affected (roles, specific role, playbooks, docs) - This category should contain all features which have been deprecated and will be removed in a future release. This section should not appear in patch releases according to semantic versioning.
+
+security_fixes:
+  - area affected (roles, specific role, playbooks, docs) - This category should mention all security relevant fixes, including CVEs if available.
+
+bugfixes:
+  - area affected (roles, specific role, playbooks, docs) - This category should be a list of all bug fixes which fix a bug that was present in a previous version.
+
+known_issues:
+  - area affected (roles, specific role, playbooks, docs) - This category should mention known issues that are currently not fixed or will not be fixed.
+
+trivial:
+  - area affected (roles, specific role, playbooks, docs) - This category will **not be shown** in the changelog. It can be used to describe changes that are not touching user-facing code, like changes in tests. This is useful if every PR is required to have a changelog fragment.

--- a/grafana/common/Prometheus_Alerts.json
+++ b/grafana/common/Prometheus_Alerts.json
@@ -3,164 +3,78 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
   },
   "editable": false,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 8,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
-      "columns": [],
-      "datasource": null,
-      "fontSize": "100%",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crunchyprometheus"
+      },
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 24,
         "x": 0,
         "y": 0
       },
-      "id": 2,
-      "links": [],
-      "options": {},
-      "pageSize": null,
-      "scroll": true,
-      "showHeader": true,
-      "sort": {
-        "col": 0,
-        "desc": true
+      "id": 5,
+      "options": {
+        "alertInstanceLabelFilter": "",
+        "alertName": "",
+        "dashboardAlerts": false,
+        "datasource": "PROMETHEUS",
+        "groupBy": [],
+        "groupMode": "default",
+        "maxItems": 20,
+        "sortOrder": 1,
+        "stateFilter": {
+          "error": true,
+          "firing": true,
+          "noData": false,
+          "normal": false,
+          "pending": true
+        },
+        "viewMode": "list"
       },
-      "styles": [
-        {
-          "alias": "Time",
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "link": false,
-          "pattern": "Time",
-          "type": "date"
-        },
-        {
-          "alias": "",
-          "colorMode": "row",
-          "colors": [
-            "rgba(50, 172, 45, 0.97)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(245, 54, 54, 0.9)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 0,
-          "link": false,
-          "mappingType": 1,
-          "pattern": "severity_num",
-          "thresholds": [
-            "200",
-            "300"
-          ],
-          "type": "string",
-          "unit": "none"
-        },
-        {
-          "alias": "",
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
-          "pattern": "__name__",
-          "thresholds": [],
-          "type": "hidden",
-          "unit": "short"
-        },
-        {
-          "alias": "",
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
-          "pattern": "alertstate",
-          "thresholds": [],
-          "type": "hidden",
-          "unit": "short"
-        },
-        {
-          "alias": "",
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
-          "pattern": "Value",
-          "thresholds": [],
-          "type": "hidden",
-          "unit": "short"
-        },
-        {
-          "alias": "",
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
-          "pattern": "alert_value",
-          "thresholds": [],
-          "type": "number",
-          "unit": "none"
-        }
-      ],
-      "targets": [
-        {
-          "expr": "ALERTS{alertstate=\"firing\"}",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "intervalFactor": 4,
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
       "title": "Active Alerts",
-      "transform": "table",
-      "type": "table"
+      "type": "alertlist"
     },
     {
       "columns": [],
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "crunchyprometheus"
+      },
       "fontSize": "100%",
       "gridPos": {
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 7
+        "y": 8
       },
       "id": 3,
       "links": [],
-      "options": {},
-      "pageSize": null,
       "scroll": true,
       "showHeader": true,
       "sort": {
@@ -170,6 +84,7 @@
       "styles": [
         {
           "alias": "Time",
+          "align": "auto",
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "link": false,
           "pattern": "Time",
@@ -177,6 +92,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": "row",
           "colors": [
             "rgba(50, 172, 45, 0.97)",
@@ -197,7 +113,7 @@
         },
         {
           "alias": "",
-          "colorMode": null,
+          "align": "auto",
           "colors": [
             "rgba(245, 54, 54, 0.9)",
             "rgba(237, 129, 40, 0.89)",
@@ -213,7 +129,7 @@
         },
         {
           "alias": "",
-          "colorMode": null,
+          "align": "auto",
           "colors": [
             "rgba(245, 54, 54, 0.9)",
             "rgba(237, 129, 40, 0.89)",
@@ -229,7 +145,7 @@
         },
         {
           "alias": "",
-          "colorMode": null,
+          "align": "auto",
           "colors": [
             "rgba(245, 54, 54, 0.9)",
             "rgba(237, 129, 40, 0.89)",
@@ -245,7 +161,7 @@
         },
         {
           "alias": "",
-          "colorMode": null,
+          "align": "auto",
           "colors": [
             "rgba(245, 54, 54, 0.9)",
             "rgba(237, 129, 40, 0.89)",
@@ -262,6 +178,10 @@
       ],
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "crunchyprometheus"
+          },
           "expr": "ALERTS{alertstate=\"firing\"}",
           "format": "table",
           "instant": false,
@@ -274,11 +194,11 @@
       "timeFrom": "1w",
       "title": "Alert History (1 week)",
       "transform": "table",
-      "type": "table"
+      "type": "table-old"
     }
   ],
   "refresh": "5m",
-  "schemaVersion": 21,
+  "schemaVersion": 37,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -304,5 +224,6 @@
   "timezone": "",
   "title": "Prometheus Alerts",
   "uid": "QTsttxNmk",
-  "version": 2
+  "version": 1,
+  "weekStart": ""
 }

--- a/grafana/common/crunchy_grafana_datasource.yml
+++ b/grafana/common/crunchy_grafana_datasource.yml
@@ -7,9 +7,15 @@
 # config file version
 apiVersion: 1
 
+deleteDatasources:
+  - name: PROMETHEUS
+    orgId: 1
+  - name: ALERTMANAGER
+    orgId: 1
+
 datasources:
   - name: PROMETHEUS
-    uid: PDC1078F23EBDF0E5
+    uid: crunchyprometheus
     type: prometheus
     access: proxy
     url: http://localhost:9090
@@ -17,4 +23,16 @@ datasources:
     editable: False
     orgId: 1
     version: 1
+    jsonData:
+      manageAlerts: 'true'
+      alertmanagerUid: 'crunchyalertmanager'
+  - name: ALERTMANAGER
+    name: 'ALERTMANAGER'
+    uid: crunchyalertmanager
+    type: alertmanager
+    url: http://localhost:9093
+    access: proxy
+    jsonData:
+      implementation: 'prometheus'
+      handleGrafanaManagedAlerts: 'false'
 

--- a/grafana/common/crunchy_grafana_datasource.yml
+++ b/grafana/common/crunchy_grafana_datasource.yml
@@ -27,7 +27,6 @@ datasources:
       manageAlerts: 'true'
       alertmanagerUid: 'crunchyalertmanager'
   - name: ALERTMANAGER
-    name: 'ALERTMANAGER'
     uid: crunchyalertmanager
     type: alertmanager
     url: http://localhost:9093

--- a/hugo/content/grafana/_index.md
+++ b/hugo/content/grafana/_index.md
@@ -123,7 +123,7 @@ Navigate to the web interface: https://&lt;ip-address&gt;:3000. Log in with admi
 
 Grafana provides the ability to automatically provision datasources and dashboards via configuration files instead of having to manually import them either through the web interface or the API. Note that provisioned dashboards can no longer be directly edited and saved via the web interface. See the Grafana documentation for how to edit/save provisioned dashboards: http://docs.grafana.org/administration/provisioning/#making-changes-to-a-provisioned-dashboard. If you'd like to customize these dashboards, we recommend first adding them via provisioning then saving them with a new name. You can then either manage them via the web interface or add them to the provisioning system.
 
-The extras package takes care of putting all these files in place. If you did not use the crunchy package to install Grafana, see the additional instructions above. Once that is done, the only additional setup that needs to be done is to set the "provisioning" option in the `grafana.ini` to point to the top level directory if it hasn't been done already. 
+The extras package takes care of putting all these files in place. If you did not use the Crunchy package to install Grafana, see the additional instructions above. Once that is done, the only additional setup that needs to be done is to set the "provisioning" option in the `grafana.ini` to point to the top level directory if it hasn't been done already. 
 
 ```ini
 [paths]

--- a/hugo/content/grafana/_index.md
+++ b/hugo/content/grafana/_index.md
@@ -35,7 +35,7 @@ pgMonitor comes with several dashboards ready to be used with automatic provisio
 |OS Overview            | Overview.json| Provides an overview that shows the up status of each system monitored by pgMonitor. |
 |||
 |ETCD Details           | ETCD_Details.json | Provides details on the status of the ETCD cluster monitored by pgMonitor. |
-|Prometheus Alerts      | Prometheus_Alerts.json| Provides a summary list of current and recent alerts that have fired in Prometheus. |
+|Prometheus Alerts      | Prometheus_Alerts.json| Provides a summary list of current and recent alerts that have fired in Prometheus. Interaction with the Alertmanager to silence alerts is possible from the Alerting menu in Grafana. |
 
 ## Installation {#installation}
 
@@ -68,15 +68,13 @@ mkdir -p /etc/grafana/crunchy_dashboards
 | grafana/crunchy_grafana_datasource.yml    | /etc/grafana/provisioning/datasources/datasource.yml |  
 | grafana/crunchy_grafana_dashboards.yml    | /etc/grafana/provisioning/dashboards/dashboards.yml |  
 
-Review the {{< shell >}}crunchy_grafana_datasource.yml{{< /shell >}}} file to ensure it is looking at your Prometheus database. The included file assumes Grafana and Prometheus are running on the same system. DO NOT CHANGE the datasource {{< yaml >}}name{{< /yaml >}} if you will be using the dashboards provided in this repo. They assume that name and will not work otherwise. Any other options can be changed as needed. Save the {{< shell >}}crunchy_grafana_datasource.yml{{< /shell >}} file and rename it to {{< shell >}}/etc/grafana/provisioning/datasources/datasources.yml{{< /shell >}}. Restart grafana and confirm through the web interface that the datasource was provisioned and working.
+Review the {{< shell >}}crunchy_grafana_datasource.yml{{< /shell >}}} file to ensure it is looking at your Prometheus database. The included file assumes Grafana,  Prometheus, and Alertmanager are running on the same system. DO NOT CHANGE the datasource {{< yaml >}}uid{{< /yaml >}} or {{< yaml >}}name{{< /yaml >}} fields if you will be using the dashboards provided in this repo. They assume those values and will not work otherwise. Any other options can be changed as needed. Save the {{< shell >}}crunchy_grafana_datasource.yml{{< /shell >}} file and rename it to {{< shell >}}/etc/grafana/provisioning/datasources/datasources.yml{{< /shell >}}. Restart grafana and confirm through the web interface that the datasource was provisioned and working.
 
 Review the {{< shell >}}crunchy_grafana_dashboards.yml{{< /shell >}} file to ensure it's looking at where you stored the provided dashboards. By default it is looking in {{< shell >}}/etc/grafana/crunchy_dashboards{{< /shell >}}. Save this file and rename it to {{< shell >}}/etc/grafana/provisioning/dashboards/dashboards.yml{{< /shell >}}. Restart grafana so it picks up the new config.
 
 Save all of the desired .json dashboard files to the {{< shell >}}/etc/grafana/crunchy_dashboards{{< /shell >}} folder. All of them are not required, so if there is a dashboard you do not need, it can be left out.
 
 ## Upgrading {#upgrading}
-
-If you'd like to take advantage of the new provisioning system in Grafana 5 provided by pgmonitor 2.x, we recommend either renaming or deleting your existing datasources and dashboards so there are no issues when the provisioned versions are imported.
 
 Please review the ChangeLog for pgMonitor and take note of any changes to metric names and/or dashboards. Note that if you are using the included dashboards that are managed via the provisioning system, they will automatically be updated. If you've made any changes to configuration files and kept their default names, the package will not overwrite them and will instead make a new file with an {{< shell >}}*.rpmnew{{< /shell >}} extension. You can compare your file and the new one and incorporate any changes as needed or desired.
 
@@ -125,7 +123,7 @@ Navigate to the web interface: https://&lt;ip-address&gt;:3000. Log in with admi
 
 Grafana provides the ability to automatically provision datasources and dashboards via configuration files instead of having to manually import them either through the web interface or the API. Note that provisioned dashboards can no longer be directly edited and saved via the web interface. See the Grafana documentation for how to edit/save provisioned dashboards: http://docs.grafana.org/administration/provisioning/#making-changes-to-a-provisioned-dashboard. If you'd like to customize these dashboards, we recommend first adding them via provisioning then saving them with a new name. You can then either manage them via the web interface or add them to the provisioning system.
 
-The extras package takes care of putting all these files in place. If you did not use the crunchy package to install Grafana, see the additional instructions above. Once that is done, the only additional setup that needs to be done is to set the "provisioning" option in the `grafana.ini` to point to the top level directory if it hasn't been done already. If you're upgrading from Grafana 4.x to 5.x, you will have to add the "provisioning" option to the `[paths]` section of the `grafana.ini` file. Once that is done, just restart grafana and all datasources and dashboards should appear.
+The extras package takes care of putting all these files in place. If you did not use the crunchy package to install Grafana, see the additional instructions above. Once that is done, the only additional setup that needs to be done is to set the "provisioning" option in the `grafana.ini` to point to the top level directory if it hasn't been done already. 
 
 ```ini
 [paths]


### PR DESCRIPTION
# Description  

Add support for the new Alertmanager API interface in Grafana. Automatically provisions a new alertmanager and associates that with the Prometheus datasource.

Ran into an issue with the association not working in 9.5 when testing there, but it works in 9.2 :confused: 
https://community.grafana.com/t/prometheus-alertmanager-association-missing-in-9-5/102703

Please indicate what kind of change your PR includes (multiple selections are acceptable):

- [ ] Bugfix
- [x] Enhancement
- [ ] Breaking Change
- [ ] Documentation

PRs should be against existing issues, so please list each issue using a separate 'closes' line:

closes #250 

If this PR depends on another PR or resolution of another issue, please indicate that here using a separate 'depends' line for each dependency.

depends on #

If you have an **external** dependency (packages, portal updates, etc), add the 'BLOCKED' tag to your PR.


## Testing
*None of the testing listed below is optional.*

- Installation method:  
    - [ ] Binary install from source, version:  
    - [x] OS package repository, distro, and version:  Grafana 9.2 from public repo, 9.5 from S3
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [ ] Other:  
- [ ] PostgreSQL, Specify version(s):  
- [ ] docs tested with hugo version(s):  

### Code testing

Have you tested your changes against:
- [x] RedHat/CentOS
- [ ] Ubuntu
- [ ] SLES
- [ ] Not applicable

If your code touches postgres_exporter, have you:
- [ ] Tested against all versions of PostgreSQL affected
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches node_exporter, have you:
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches Prometheus, have you:
- [ ] Ensured all configuration changes pass `promtool check config`
- [ ] Ensured all alert rule changes pass `promtool check rules`
- [ ] Prometheus runs without issue
- [ ] Alertmanager runs without issue
- [x] Not applicable

If your code touches Grafana, have you:
- [ ] Ensured Grafana runs without issue
- [ ] Ensured relevant dashboards load without issue
- [x] Not applicable

### Checklist:
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [x] the release notes  
    - [ ] the upgrade doc  
