### PR TITLE
updating pgbackrest-info.sh to set the log-level to warn

### DIFF
--- a/changelogs/fragments/371.yml
+++ b/changelogs/fragments/371.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - backrest info script - Force the console log level to ``warn`` when running pgbackrest-info.sh to ensure metrics are parsed from the JSON properly.

--- a/postgres_exporter/linux/pgbackrest-info.sh
+++ b/postgres_exporter/linux/pgbackrest-info.sh
@@ -22,12 +22,12 @@ fi
 conf="default"
 
 if [ -z "$BACKREST_CONFIGS" ] && [ -z "$BACKREST_STANZAS" ]; then
-    echo $(echo -n "$conf|" | tr '/' '_'; pgbackrest --output=json info | tr -d '\n')
+    echo $(echo -n "$conf|" | tr '/' '_'; pgbackrest --log-level-console=warn --output=json info | tr -d '\n')
 elif [ ! -z "$BACKREST_CONFIGS" ] && [ -z "$BACKREST_STANZAS" ]; then
     read -r -a config_array <<< "$BACKREST_CONFIGS"
     for conf in "${config_array[@]}"
     do
-      echo $(echo -n "$conf|" | tr '/' '_'; pgbackrest --config=$conf --output=json info | tr -d '\n') | grep $SYSTEM_ID
+      echo $(echo -n "$conf|" | tr '/' '_'; pgbackrest --log-level-console=warn --config=$conf --output=json info | tr -d '\n') | grep $SYSTEM_ID
       if [ $? == 0 ]; then
         break
       fi
@@ -37,7 +37,7 @@ elif [ -z "$BACKREST_CONFIGS" ] && [ ! -z "$BACKREST_STANZAS" ]; then
     for stanza in "${stanza_array[@]}"
     do
       export PGBACKREST_STANZA=$stanza
-      echo $(echo -n "$conf|" | tr '/' '_'; pgbackrest --output=json info | tr -d '\n') | grep $SYSTEM_ID
+      echo $(echo -n "$conf|" | tr '/' '_'; pgbackrest --log-level-console=warn --output=json info | tr -d '\n') | grep $SYSTEM_ID
       if [ $? == 0 ]; then
         break
       fi


### PR DESCRIPTION
# Description  
https://github.com/CrunchyData/pgmonitor/issues/371
ccp_backrest_* metrics not collecting when log level is set to debug with the following errors:

```
Sep 22 22:38:34 u4-vpdb-ha2-01.sonic.com postgres_exporter[94461]: ts=2023-09-22T22:38:34.755Z caller=namespace.go:236 level=info err="Error running query on database \"\": ccp_backrest_last_diff_backup pq: end-of-copy marker corrupt"
Sep 22 22:38:35 u4-vpdb-ha2-01.sonic.com postgres_exporter[94461]: ts=2023-09-22T22:38:35.188Z caller=namespace.go:236 level=info err="Error running query on database \"\": ccp_backrest_last_full_backup pq: end-of-copy marker corrupt"
```

*Please fill this template out fully; failure to do so can result in rejection of your PR.*

Please describe the changes made by your PR. This description should be at a high-level but detailed enough that a reviewer understands the scope of the fix or enhancement and can easily judge the PRs validity at addressing the stated issue/feature. Please fully describe any new or changed feature and whether said change is user-facing or not:

Updated pgbackrest-info.sh to set the console log level to warn (the default) when calling the pgbackrest commands. This will ensure the output is correct, no matter what the user has the log level set to. 

Please indicate what kind of change your PR includes (multiple selections are acceptable):

- [x] Bugfix
- [ ] Enhancement
- [ ] Breaking Change
- [ ] Documentation

PRs should be against existing issues, so please list each issue using a separate 'closes' line:

closes #371 

If this PR depends on another PR or resolution of another issue, please indicate that here using a separate 'depends' line for each dependency.

depends on # n/a

If you have an **external** dependency (packages, portal updates, etc), add the 'BLOCKED' tag to your PR.


## Testing
*None of the testing listed below is optional.*

- Installation method:  
    - [ ] Binary install from source, version:  
    - [ ] OS package repository, distro, and version:  
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [x] Other:  Crunchy HA Postgresql Playbooks
- [ ] PostgreSQL, Specify version(s):  
- [ ] docs tested with hugo version(s):  

### Code testing

Have you tested your changes against:
- [ ] RedHat/CentOS
- [x] Ubuntu
- [ ] SLES
- [ ] Not applicable

If your code touches postgres_exporter, have you:
- [ ] Tested against all versions of PostgreSQL affected
- [x] Ensure that exporter runs with no scrape errors
- [ ] Not applicable

If your code touches node_exporter, have you:
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches Prometheus, have you:
- [ ] Ensured all configuration changes pass `promtool check config`
- [ ] Ensured all alert rule changes pass `promtool check rules`
- [ ] Prometheus runs without issue
- [ ] Alertmanager runs without issue
- [x] Not applicable

If your code touches Grafana, have you:
- [ ] Ensured Grafana runs without issue
- [ ] Ensured relevant dashboards load without issue
- [x] Not applicable

### Checklist:
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  
