### PR TITLE
feature: update dependencies for monitoring services

### DIFF
--- a/build/packages.yml
+++ b/build/packages.yml
@@ -58,7 +58,7 @@ packages:
           - { source: "postgres_exporter/linux/pgbackrest-info.sh", target: "/usr/bin/pgbackrest-info.sh", mode: "0755", type: "file", rpm_new: false, owner: "ccp_monitoring", group: "ccp_monitoring" }
           - { source: "postgres_exporter/linux/pgmonitor.conf", target: "/etc/pgmonitor.conf", mode: "0644", type: "file", rpm_new: false, owner: "ccp_monitoring", group: "ccp_monitoring" }
         pkg_dependency:
-          - { pkg_name: "postgres-exporter", gte: 0.13.2, lt: 0.16.0 }
+          - { pkg_name: "postgres-exporter", gte: 0.10.1, lt: 0.16.0 }
         upstream_repo: "https://github.com/CrunchyData/pgmonitor"
 
     - pgmonitor-prometheus-extras:
@@ -103,7 +103,7 @@ packages:
         pkg_conflict:
           - { pkg_name: "grafana-containers" }
         pkg_dependency:
-          - { pkg_name: "grafana", gte: 9.5.13, lt: 10.0.0 }
+          - { pkg_name: "grafana", gte: 9.2.19, lt: 10.0.0 }
         upstream_repo: "https://github.com/CrunchyData/pgmonitor"
 
     - pg_bloat_check:

--- a/build/packages.yml
+++ b/build/packages.yml
@@ -47,7 +47,7 @@ packages:
           - { source: "node_exporter/linux/sysconfig.node_exporter", target: "/etc/sysconfig/node_exporter", mode: "0640", type: "file", rpm_new: true, owner: "ccp_monitoring", group: "ccp_monitoring" }
           - { target: "/var/lib/ccp_monitoring/node_exporter/", mode: "0700", type: "folder", rpm_new: false, owner: "ccp_monitoring", group: "ccp_monitoring" }
         pkg_dependency:
-          - { pkg_name: "node-exporter", gte: 1.4.0, lt: 1.5.0 }
+          - { pkg_name: "node-exporter", gte: 1.5.0, lt: 1.7.0 }
         remove_files:
           - { target: "/etc/systemd/system/node_exporter.service.d/crunchy-node-exporter-service-el7.conf" }
         upstream_repo: "https://github.com/CrunchyData/pgmonitor"

--- a/build/packages.yml
+++ b/build/packages.yml
@@ -58,7 +58,7 @@ packages:
           - { source: "postgres_exporter/linux/pgbackrest-info.sh", target: "/usr/bin/pgbackrest-info.sh", mode: "0755", type: "file", rpm_new: false, owner: "ccp_monitoring", group: "ccp_monitoring" }
           - { source: "postgres_exporter/linux/pgmonitor.conf", target: "/etc/pgmonitor.conf", mode: "0644", type: "file", rpm_new: false, owner: "ccp_monitoring", group: "ccp_monitoring" }
         pkg_dependency:
-          - { pkg_name: "postgres-exporter", gte: 0.10.1, lt: 0.12.0 }
+          - { pkg_name: "postgres-exporter", gte: 0.13.2, lt: 0.16.0 }
         upstream_repo: "https://github.com/CrunchyData/pgmonitor"
 
     - pgmonitor-prometheus-extras:
@@ -77,7 +77,7 @@ packages:
         pkg_conflict:
           - { pkg_name: "pgmonitor-prometheus-containers" }
         pkg_dependency:
-          - { pkg_name: "prometheus2", gte: 2.38.0 , lt: 2.40.0 }
+          - { pkg_name: "prometheus2", gte: 2.38.0 , lt: 2.48.0 }
         remove_files:
           - { target: "/etc/systemd/system/prometheus.service.d/crunchy-prometheus-service-el7.conf" }
         upstream_repo: "https://github.com/CrunchyData/pgmonitor"
@@ -89,7 +89,7 @@ packages:
           - { source: "/etc/systemd/system/sysconfig.alertmanager", target: "/etc/sysconfig/alertmanager", mode: "0640", type: "file", rpm_new: false, owner: "ccp_monitoring", group: "ccp_monitoring" }
           - { target: "/var/lib/ccp_monitoring/prometheus", mode: "0750", type: "folder", rpm_new: false, owner: "ccp_monitoring", group: "ccp_monitoring" }
         pkg_dependency:
-          - { pkg_name: "alertmanager", gte: 0.23.0, lt: 0.25.0 }
+          - { pkg_name: "alertmanager", gte: 0.23.0, lt: 0.27.0 }
         remove_files:
           - { target: "/etc/systemd/system/alertmanager.service.d/crunchy-alertmanager-service-el7.conf" }
         upstream_repo: "https://github.com/CrunchyData/pgmonitor"
@@ -103,7 +103,7 @@ packages:
         pkg_conflict:
           - { pkg_name: "grafana-containers" }
         pkg_dependency:
-          - { pkg_name: "grafana", gte: 9.2.19, lt: 9.3.0 }
+          - { pkg_name: "grafana", gte: 9.5.13, lt: 10.0.0 }
         upstream_repo: "https://github.com/CrunchyData/pgmonitor"
 
     - pg_bloat_check:

--- a/changelogs/fragments/250.yml
+++ b/changelogs/fragments/250.yml
@@ -1,3 +1,4 @@
+---
 major_changes:
   - grafana - add Alertmanager datasource to Grafana to allow direct alert management via Grafana
   - grafana - update 'Prometheus Alerts' dashboard to include new alert panel interface for active alerts  

--- a/changelogs/fragments/378.yml
+++ b/changelogs/fragments/378.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - node_exporter - update build dependencies for node-exporter-extras package

--- a/changelogs/fragments/378.yml
+++ b/changelogs/fragments/378.yml
@@ -1,7 +1,8 @@
 ---
-trivial:
-  - node_exporter - update build dependencies for node-exporter-extras package
-  - postgres_exporter - minimum version 0.13.2, maximum 0.15
-  - prometheus - minimum version 2.38, maximum 2.47
-  - alertmanager - minimum version 0.23, maximum 0.26
-  - grafana - minimum version 9.5, maximum 9.5
+minor_changes:
+  - node_exporter - minimum version 1.5.0, maximum 1.6.x
+minor_changes:
+  - postgres_exporter - minimum version 0.13.2, maximum 0.15.x
+  - prometheus - minimum version 2.38, maximum 2.47.x
+  - alertmanager - minimum version 0.23, maximum 0.26.x
+  - grafana - minimum version 9.5, maximum 9.9.x

--- a/changelogs/fragments/378.yml
+++ b/changelogs/fragments/378.yml
@@ -1,3 +1,7 @@
 ---
 trivial:
   - node_exporter - update build dependencies for node-exporter-extras package
+  - postgres_exporter - minimum version 0.13.2, maximum 0.15
+  - prometheus - minimum version 2.38, maximum 2.47
+  - alertmanager - minimum version 0.23, maximum 0.26
+  - grafana - minimum version 9.5, maximum 9.5

--- a/changelogs/fragments/378.yml
+++ b/changelogs/fragments/378.yml
@@ -1,7 +1,6 @@
 ---
 minor_changes:
   - node_exporter - minimum version 1.5.0, maximum 1.6.x
-minor_changes:
   - postgres_exporter - minimum version 0.13.2, maximum 0.15.x
   - prometheus - minimum version 2.38, maximum 2.47.x
   - alertmanager - minimum version 0.23, maximum 0.26.x

--- a/changelogs/fragments/378.yml
+++ b/changelogs/fragments/378.yml
@@ -1,7 +1,7 @@
 ---
 minor_changes:
   - node_exporter - minimum version 1.5.0, maximum 1.6.x
-  - postgres_exporter - minimum version 0.13.2, maximum 0.15.x
+  - postgres_exporter - minimum version 0.10.1, maximum 0.15.x
   - prometheus - minimum version 2.38, maximum 2.47.x
   - alertmanager - minimum version 0.23, maximum 0.26.x
-  - grafana - minimum version 9.5, maximum 9.9.x
+  - grafana - minimum version 9.2.19, maximum 9.9.x


### PR DESCRIPTION
# Description  

Update build dependencies to the following 
* node_exporter >= 1.5, < 1.7  (fixes new startup parameter name for tls/auth)
* postgres_exporter >= 0.10.1, < 0.16.0
* prometheus >= 2.38, < 2.48
* alertmanager >= 0.23, < 0.27
* grafana >= 9.2.19, < 10 

Please indicate what kind of change your PR includes (multiple selections are acceptable):

- [ ] Bugfix
- [x] Enhancement
- [ ] Breaking Change
- [ ] Documentation

PRs should be against existing issues, so please list each issue using a separate 'closes' line:

closes #378 

## Testing
*None of the testing listed below is optional.*

- Installation method:  
    - [ ] Binary install from source, version:  
    - [ ] OS package repository, distro, and version:  
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [x] Other:  
- [ ] PostgreSQL, Specify version(s):  
- [ ] docs tested with hugo version(s):  

### Code testing

Have you tested your changes against:
- [ ] RedHat/CentOS
- [ ] Ubuntu
- [ ] SLES
- [x] Not applicable

If your code touches postgres_exporter, have you:
- [ ] Tested against all versions of PostgreSQL affected
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches node_exporter, have you:
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches Prometheus, have you:
- [ ] Ensured all configuration changes pass `promtool check config`
- [ ] Ensured all alert rule changes pass `promtool check rules`
- [ ] Prometheus runs without issue
- [ ] Alertmanager runs without issue
- [x] Not applicable

If your code touches Grafana, have you:
- [ ] Ensured Grafana runs without issue
- [ ] Ensured relevant dashboards load without issue
- [x] Not applicable

### Checklist:
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [x] the release notes  
    - [ ] the upgrade doc  
