### PR TITLE
feature: update dependencies for monitoring services

### DIFF
--- a/build/packages.yml
+++ b/build/packages.yml
@@ -47,7 +47,7 @@ packages:
           - { source: "node_exporter/linux/sysconfig.node_exporter", target: "/etc/sysconfig/node_exporter", mode: "0640", type: "file", rpm_new: true, owner: "ccp_monitoring", group: "ccp_monitoring" }
           - { target: "/var/lib/ccp_monitoring/node_exporter/", mode: "0700", type: "folder", rpm_new: false, owner: "ccp_monitoring", group: "ccp_monitoring" }
         pkg_dependency:
-          - { pkg_name: "node-exporter", gte: 1.5.0, lt: 1.7.0 }
+          - { pkg_name: "node-exporter", gte: 1.5.0, lt: 1.8.0 }
         remove_files:
           - { target: "/etc/systemd/system/node_exporter.service.d/crunchy-node-exporter-service-el7.conf" }
         upstream_repo: "https://github.com/CrunchyData/pgmonitor"

--- a/changelogs/fragments/378.yml
+++ b/changelogs/fragments/378.yml
@@ -1,6 +1,6 @@
 ---
 minor_changes:
-  - node_exporter - minimum version 1.5.0, maximum 1.6.x
+  - node_exporter - minimum version 1.5.0, maximum 1.7.x
   - postgres_exporter - minimum version 0.10.1, maximum 0.15.x
   - prometheus - minimum version 2.38, maximum 2.47.x
   - alertmanager - minimum version 0.23, maximum 0.26.x


### PR DESCRIPTION
# Description  

Update dependencies for node_exporter latest version

Please indicate what kind of change your PR includes (multiple selections are acceptable):

- [ ] Bugfix
- [x] Enhancement
- [ ] Breaking Change
- [ ] Documentation

PRs should be against existing issues, so please list each issue using a separate 'closes' line:

closes #379 

## Testing
*None of the testing listed below is optional.*

- Installation method:  
    - [ ] Binary install from source, version:  
    - [ ] OS package repository, distro, and version:  
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [ ] Other:  
- [ ] PostgreSQL, Specify version(s):  
- [ ] docs tested with hugo version(s):  

### Code testing

Have you tested your changes against:
- [ ] RedHat/CentOS
- [ ] Ubuntu
- [ ] SLES
- [x] Not applicable

If your code touches postgres_exporter, have you:
- [ ] Tested against all versions of PostgreSQL affected
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches node_exporter, have you:
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches Prometheus, have you:
- [ ] Ensured all configuration changes pass `promtool check config`
- [ ] Ensured all alert rule changes pass `promtool check rules`
- [ ] Prometheus runs without issue
- [ ] Alertmanager runs without issue
- [x] Not applicable

If your code touches Grafana, have you:
- [ ] Ensured Grafana runs without issue
- [ ] Ensured relevant dashboards load without issue
- [x] Not applicable

### Checklist:
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  
