### PR TITLE
Add OOMKiller Alert

### DIFF
--- a/changelogs/fragments/387.yml
+++ b/changelogs/fragments/387.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - prometheus - Added OOMKiller Alert using node_exporter metrics

--- a/prometheus/linux/alert-rules.d/crunchy-alert-rules-node.yml.example
+++ b/prometheus/linux/alert-rules.d/crunchy-alert-rules-node.yml.example
@@ -92,6 +92,16 @@ groups:
     annotations:
       description: 'Memory available for target {{ $labels.job }} is at {{ $value }}%'
 
+  - alert: OOMKiller
+    expr: changes(node_vmstat_oom_kill[5m]) != 0
+    for: 1m
+    labels:
+      service: system
+      severity: warning
+      severity_num: 200
+    annotations:
+      description: 'Out of Memory Killer has triggered on {{ $labels.job }}'
+
   - alert: SwapUsage
     expr: (100 - (100 * (node_memory_SwapFree_bytes / node_memory_SwapTotal_bytes))) > 60
     for: 1m


### PR DESCRIPTION
# Description  

Linux has been tracking OOMKiller stats in /proc/vmstat since Kernel 2.6.36. node_exporter also provides this statistic as part of standard exposed metrics.

If a host hits an OOM state, it's likely that an alert should be generated, so that it could be reviewed for hardware or system resource faults.

This change adds a new user-facing default alert to account for any OOMKiller events.

Please indicate what kind of change your PR includes (multiple selections are acceptable):

- [ ] Bugfix
- [x] Enhancement
- [ ] Breaking Change
- [ ] Documentation


closes #388 


## Testing
*None of the testing listed below is optional.*

- Installation method:  
    - [x] Binary install from source, version: Git SHA `e5d8197`
    - [ ] OS package repository, distro, and version:  
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [ ] Other:  
- [x] PostgreSQL, Specify version(s): PG 12-16 
- [x] docs tested with hugo version(s): No documentation changes.

### Code testing

Have you tested your changes against:
- [x] RedHat/CentOS
- [x] Ubuntu
- [ ] SLES
- [ ] Not applicable

If your code touches node_exporter, have you:
- [x] Ensure that exporter runs with no scrape errors
- [ ] Not applicable

If your code touches Prometheus, have you:
- [x] Ensured all configuration changes pass `promtool check config`
- [x] Ensured all alert rule changes pass `promtool check rules`
- [x] Prometheus runs without issue
- [x] Alertmanager runs without issue
- [ ] Not applicable

### Checklist:
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  
