### PR TITLE
Add a stat panel showing the pod type to Pod Details. Implements #389

### DIFF
--- a/grafana/containers/pod_details.json
+++ b/grafana/containers/pod_details.json
@@ -60,6 +60,73 @@
   ],
   "panels": [
     {
+      "datasource": "PROMETHEUS",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "index": 0,
+                  "text": "Primary"
+                },
+                "1": {
+                  "index": 1,
+                  "text": "Replica"
+                }
+              },
+              "type": "value"
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 17,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "valueSize": 30
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.2.20",
+      "targets": [
+        {
+          "datasource": "PROMETHEUS",
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "pg_replication_is_replica{pod=\"[[pod]]\", pg_cluster=\"[[cluster]]\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Pod Type",
+      "type": "stat"
+    },
+    {
       "aliasColors": {
         "% Throttled": "yellow",
         "% Used": "blue",


### PR DESCRIPTION
# Description

See #389 for feature details.

Add a stat panel showing the pod type to Pod Details. Aids debugging system issues by indicating if the pod you're looking at is the write node / a replica.

Please indicate what kind of change your PR includes (multiple selections are acceptable):

- [ ] Bugfix
- [x] Enhancement
- [ ] Breaking Change
- [ ] Documentation

PRs should be against existing issues, so please list each issue using a separate 'closes' line:

closes #389 

## Testing
*None of the testing listed below is optional.*

- Installation method:  
    - [ ] Binary install from source, version:  
    - [ ] OS package repository, distro, and version:  
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [ ] Other:  
- [ ] PostgreSQL, Specify version(s):  
- [ ] docs tested with hugo version(s):  

### Code testing

Have you tested your changes against:
- [ ] RedHat/CentOS
- [ ] Ubuntu
- [ ] SLES
- [ ] Not applicable

If your code touches postgres_exporter, have you:
- [ ] Tested against all versions of PostgreSQL affected
- [ ] Ensure that exporter runs with no scrape errors
- [ ] Not applicable

If your code touches node_exporter, have you:
- [ ] Ensure that exporter runs with no scrape errors
- [ ] Not applicable

If your code touches Prometheus, have you:
- [ ] Ensured all configuration changes pass `promtool check config`
- [ ] Ensured all alert rule changes pass `promtool check rules`
- [ ] Prometheus runs without issue
- [ ] Alertmanager runs without issue
- [ ] Not applicable

If your code touches Grafana, have you:
- [x] Ensured Grafana runs without issue
- [x] Ensured relevant dashboards load without issue
- [ ] Not applicable

### Checklist:
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  
