### PR TITLE
docs: update os and bouncer supported versions

### DIFF
--- a/changelogs/fragments/397.yml
+++ b/changelogs/fragments/397.yml
@@ -1,0 +1,2 @@
+trivial:
+  - docs - Update OS and PgBouncer version support

--- a/hugo/content/_index.md
+++ b/hugo/content/_index.md
@@ -51,9 +51,9 @@ pgMonitor combines multiple open-source software packages and necessary configur
 
 ### Operating Systems
 
-- RHEL 7/8 (Build/Run Testing, Setup Instructions)
+- RHEL 7/8/9 (Build/Run Testing, Setup Instructions)
 - CentOS 7 (Build/Run Testing, Setup Instructions)
-- Ubuntu 20 (Build/Run Testing)
+- Ubuntu 20/22 (Build/Run Testing)
 
 ### PostgreSQL
 
@@ -65,8 +65,8 @@ pgMonitor combines multiple open-source software packages and necessary configur
 
 ### PgBouncer
 
-- PgBouncer 1.17
-- pgbouncer_fdw 1.0.0
+- PgBouncer 1.21
+- pgbouncer_fdw 1.1.0
 
 ## Installation
 

--- a/hugo/content/_index.md
+++ b/hugo/content/_index.md
@@ -65,7 +65,7 @@ pgMonitor combines multiple open-source software packages and necessary configur
 
 ### PgBouncer
 
-- PgBouncer 1.21
+- PgBouncer 1.22
 - pgbouncer_fdw 1.1.0
 
 ## Installation


### PR DESCRIPTION
# Description  

Update to include RHEL9, Ubuntu 22 & newer pgbouncer version support

Please indicate what kind of change your PR includes (multiple selections are acceptable):

- [ ] Bugfix
- [ ] Enhancement
- [ ] Breaking Change
- [x] Documentation


If you have an **external** dependency (packages, portal updates, etc), add the 'BLOCKED' tag to your PR.


## Testing
*None of the testing listed below is optional.*

- Installation method:  
    - [ ] Binary install from source, version:  
    - [ ] OS package repository, distro, and version:  
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [ ] Other:  
- [ ] PostgreSQL, Specify version(s):  
- [x] docs tested with hugo version(s):  

### Code testing

Have you tested your changes against:
- [ ] RedHat/CentOS
- [ ] Ubuntu
- [ ] SLES
- [x] Not applicable

If your code touches postgres_exporter, have you:
- [ ] Tested against all versions of PostgreSQL affected
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches node_exporter, have you:
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches Prometheus, have you:
- [ ] Ensured all configuration changes pass `promtool check config`
- [ ] Ensured all alert rule changes pass `promtool check rules`
- [ ] Prometheus runs without issue
- [ ] Alertmanager runs without issue
- [x] Not applicable

If your code touches Grafana, have you:
- [ ] Ensured Grafana runs without issue
- [ ] Ensured relevant dashboards load without issue
- [x] Not applicable

### Checklist:
- I have made corresponding changes to:  
    - [x] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  
