### PR TITLE
feat: add scrape_error_drop_interval to config example

### DIFF
--- a/changelogs/fragments/431.yml
+++ b/changelogs/fragments/431.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - sql_exporter - Add scrape_error_drop_interval setting to the configuration example

--- a/sql_exporter/common/sql_exporter.yml.example
+++ b/sql_exporter/common/sql_exporter.yml.example
@@ -12,6 +12,8 @@ global:
   max_idle_connections: 3
   # Maximum amount of time a connection may be reused to any one target. Infinite by default.
   max_connection_lifetime: 10m
+  # If scrape errors are corrected, how long until the scrape error metric is dropped from the metric output
+  scrape_error_drop_interval: 5m
 
 # The target(s) to monitor and the list of collectors to execute
 #


### PR DESCRIPTION
# Description  

Add the `scrape_error_drop_interval` setting to the sql_exporter example config file with a value of 5 minutes

Please indicate what kind of change your PR includes (multiple selections are acceptable):

- [ ] Bugfix
- [x] Enhancement
- [ ] Breaking Change
- [ ] Documentation

PRs should be against existing issues, so please list each issue using a separate 'closes' line:

closes #431

If this PR depends on another PR or resolution of another issue, please indicate that here using a separate 'depends' line for each dependency.

depends on #

If you have an **external** dependency (packages, portal updates, etc), add the 'BLOCKED' tag to your PR.


## Testing
*None of the testing listed below is optional.*

- Installation method:  
    - [ ] Binary install from source, version:  
    - [ ] OS package repository, distro, and version:  
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [ ] Other:  
- [ ] PostgreSQL, Specify version(s):  
- [ ] docs tested with hugo version(s):  

### Code testing

Have you tested your changes against:
- [x] RedHat/CentOS
- [ ] Ubuntu
- [ ] SLES
- [ ] Not applicable

If your code touches postgres_exporter, have you:
- [ ] Tested against all versions of PostgreSQL affected
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches node_exporter, have you:
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches Prometheus, have you:
- [ ] Ensured all configuration changes pass `promtool check config`
- [ ] Ensured all alert rule changes pass `promtool check rules`
- [ ] Prometheus runs without issue
- [ ] Alertmanager runs without issue
- [ x] Not applicable

If your code touches Grafana, have you:
- [ ] Ensured Grafana runs without issue
- [ ] Ensured relevant dashboards load without issue
- [x] Not applicable

### Checklist:
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [x] the release notes  
    - [ ] the upgrade doc  
