### PR TITLE
fix: fix cache hit ratio panel showing as points

### DIFF
--- a/changelogs/fragments/434.yml
+++ b/changelogs/fragments/434.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - grafana - Fix Cache Hit Ratio panel on PG Details dashboard to always be lines. Depending on data returned was sometimes being shown as points.

--- a/grafana/postgres/PG_Details.json
+++ b/grafana/postgres/PG_Details.json
@@ -1564,7 +1564,7 @@
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": false,
+            "spanNulls": true,
             "stacking": {
               "group": "A",
               "mode": "none"


### PR DESCRIPTION
# Description  

Depending on the data being returned, sometimes the Cache Hit Ratio panel on the PG Details dashboard was showing as points instead of lines. Made it so it always connects null points so it should always show as lines now.

Please indicate what kind of change your PR includes (multiple selections are acceptable):

- [x] Bugfix
- [ ] Enhancement
- [ ] Breaking Change
- [ ] Documentation

PRs should be against existing issues, so please list each issue using a separate 'closes' line:

closes #434 

If this PR depends on another PR or resolution of another issue, please indicate that here using a separate 'depends' line for each dependency.

depends on #

If you have an **external** dependency (packages, portal updates, etc), add the 'BLOCKED' tag to your PR.


## Testing
*None of the testing listed below is optional.*

- Installation method:  
    - [ ] Binary install from source, version:  
    - [ ] OS package repository, distro, and version:  
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [ ] Other:  
- [ ] PostgreSQL, Specify version(s):  
- [ ] docs tested with hugo version(s):  

### Code testing

Have you tested your changes against:
- [x] RedHat/CentOS
- [ ] Ubuntu
- [ ] Not applicable

If your code touches sql_exporter, have you:
- [ ] Tested against all versions of PostgreSQL affected
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches node_exporter, have you:
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches Prometheus, have you:
- [ ] Ensured all configuration changes pass `promtool check config`
- [ ] Ensured all alert rule changes pass `promtool check rules`
- [ ] Prometheus runs without issue
- [ ] Alertmanager runs without issue
- [x] Not applicable

If your code touches Grafana, have you:
- [x] Ensured Grafana runs without issue
- [x] Ensured relevant dashboards load without issue
- [ ] Not applicable

### Checklist:
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [x] the release notes  
    - [ ] the upgrade doc  
