### PR TITLE
fix: correct multiple metrics on backrest recovery window panel

### DIFF
--- a/changelogs/fragments/437.yml
+++ b/changelogs/fragments/437.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - grafana - Fix pgBackRest recovery window panel showing multiple values after a PostgreSQL switchover

--- a/grafana/postgres/PGBackrest.json
+++ b/grafana/postgres/PGBackrest.json
@@ -83,7 +83,7 @@
             "uid": "${ccp_datasource}"
           },
           "exemplar": true,
-          "expr": "time()- ccp_backrest_oldest_full_backup_time_seconds{stanza=\"[[backrest_stanza]]\", repo=\"[[backrest_repo]]\"} + on(job,instance) group_left() (ccp_is_in_recovery_status == 2)",
+          "expr": "max(time()- ccp_backrest_oldest_full_backup_time_seconds{stanza=\"[[backrest_stanza]]\", repo=\"[[backrest_repo]]\"} + on(job,instance) group_left() (ccp_is_in_recovery_status == 2))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"


### PR DESCRIPTION
# Description  

After a PostgreSQL switchover, the pgBackRest recovery window panel on the backrest dashboard would show odd, multiple values while the time frame includes a period both before and after the failover. Still not quite sure why Grafana is still picking up old values like that since Prometheus isn't exporting it anymore. But changed to just grab the max value since that's still the true recovery window value.

Please indicate what kind of change your PR includes (multiple selections are acceptable):

- [x] Bugfix
- [ ] Enhancement
- [ ] Breaking Change
- [ ] Documentation

PRs should be against existing issues, so please list each issue using a separate 'closes' line:

closes #437 

If this PR depends on another PR or resolution of another issue, please indicate that here using a separate 'depends' line for each dependency.

depends on #

If you have an **external** dependency (packages, portal updates, etc), add the 'BLOCKED' tag to your PR.


## Testing
*None of the testing listed below is optional.*

- Installation method:  
    - [ ] Binary install from source, version:  
    - [ ] OS package repository, distro, and version:  
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [ ] Other:  
- [ ] PostgreSQL, Specify version(s):  
- [ ] docs tested with hugo version(s):  

### Code testing

Have you tested your changes against:
- [x] RedHat/CentOS
- [ ] Ubuntu
- [ ] Not applicable

If your code touches sql_exporter, have you:
- [ ] Tested against all versions of PostgreSQL affected
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches node_exporter, have you:
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches Prometheus, have you:
- [ ] Ensured all configuration changes pass `promtool check config`
- [ ] Ensured all alert rule changes pass `promtool check rules`
- [ ] Prometheus runs without issue
- [ ] Alertmanager runs without issue
- [x] Not applicable

If your code touches Grafana, have you:
- [x] Ensured Grafana runs without issue
- [x] Ensured relevant dashboards load without issue
- [ ] Not applicable

### Checklist:
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [x] the release notes  
    - [ ] the upgrade doc  
