### PR TITLE
fix: remove metric ccp_backrest_last_info_repo_total_size_bytes

### DIFF
--- a/changelogs/fragments/459.yml
+++ b/changelogs/fragments/459.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - sql_exporter - Removed the metric `ccp_backrest_last_info_repo_total_size_bytes`. When block incremental backups are enabled, this metric is no longer available from pgBackRest.
+  - postgres_exporter - Removed the metric `ccp_backrest_last_info_repo_total_size_bytes`.
+  - grafana - Removed the `Last Backup Size (Total)` panel from the pgBackRest Grafana dashboard since it was backed by the removed metric.

--- a/grafana/postgres/PGBackrest.json
+++ b/grafana/postgres/PGBackrest.json
@@ -75,7 +75,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.2",
+      "pluginVersion": "10.4.15",
       "targets": [
         {
           "datasource": {
@@ -385,105 +385,6 @@
         "x": 0,
         "y": 11
       },
-      "id": 8,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "10.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${ccp_datasource}"
-          },
-          "exemplar": true,
-          "expr": "ccp_backrest_last_info_repo_total_size_bytes{stanza=\"[[backrest_stanza]]\", repo=\"[[backrest_repo]]\"} + on(job,instance) group_left() (ccp_is_in_recovery_status == 2)",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{backup_type}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Last Backup Size (Total)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${ccp_datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 11
-      },
       "id": 9,
       "options": {
         "legend": {
@@ -622,6 +523,6 @@
   "timezone": "",
   "title": "pgBackRest",
   "uid": "QtHwNCrik",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/hugo/content/exporter/_index.md
+++ b/hugo/content/exporter/_index.md
@@ -450,8 +450,6 @@ Backup monitoring only covers pgBackRest at this time. These metrics only need t
 
  * *ccp_backrest_last_info_repo_backup_size_bytes* - Actual size of only this individual backup in the pgbackrest repository
 
- * *ccp_backrest_last_info_repo_total_size_bytes* - Total size of this backup in the pgbackrest repository, including all required previous backups and WAL
-
  * *ccp_backrest_last_info_backup_error* - Count of errors tracked for this backup. Note this does not track incomplete backups, only errors encountered during the backup (checksum errors, file truncation, invalid headers, etc)
 
 #### Per-Database Metrics

--- a/postgres_exporter/linux/queries_backrest.yml
+++ b/postgres_exporter/linux/queries_backrest.yml
@@ -24,7 +24,6 @@ ccp_backrest_last_info:
              , a.backup_data->'database'->>'repo-key' AS repo
              , a.backup_data->>'type' AS backup_type
              , a.backup_data->'info'->'repository'->>'delta' AS repo_backup_size_bytes
-             , a.backup_data->'info'->'repository'->>'size' AS repo_total_size_bytes
              , (a.backup_data->'timestamp'->>'stop')::bigint - (a.backup_data->'timestamp'->>'start')::bigint AS backup_runtime_seconds
              , CASE
                  WHEN a.backup_data->>'error' = 'true' THEN 1
@@ -64,9 +63,6 @@ ccp_backrest_last_info:
         - repo_backup_size_bytes:
             usage: "GAUGE"
             description: "Actual size of only this individual backup in the pgbackrest repository"
-        - repo_total_size_bytes:
-            usage: "GAUGE"
-            description: "Total size of this backup in the pgbackrest repository, including all required previous backups and WAL"
         - backup_runtime_seconds:
             usage: "GAUGE"
             description: "Total runtime in seconds of this backup"

--- a/sql_exporter/common/crunchy_backrest_collector.yml
+++ b/sql_exporter/common/crunchy_backrest_collector.yml
@@ -21,16 +21,6 @@ metrics:
       - repo
       - backup_type
     query_ref: ccp_backrest_last_info
-  - metric_name: ccp_backrest_last_info_repo_total_size_bytes
-    type: gauge
-    help: "Total size of this backup in the pgbackrest repository, including all required previous backups and WAL"
-    values: [repo_total_size_bytes]
-    key_labels:
-      - config_file
-      - stanza
-      - repo
-      - backup_type
-    query_ref: ccp_backrest_last_info
   - metric_name: ccp_backrest_last_info_backup_runtime_seconds
     type: gauge
     help: "Total runtime in seconds of this backup"
@@ -107,7 +97,6 @@ queries:
         , repo
         , backup_type
         , repo_backup_size_bytes
-        , repo_total_size_bytes
         , backup_runtime_seconds
         , backup_error
       FROM pgmonitor_ext.ccp_backrest_last_info


### PR DESCRIPTION
# Description  

Remove the metric `ccp_backrest_last_info_repo_total_size_bytes` from postgres_exporter and sql_exporter.

Remove the `Last Backup Size (Total)` panel from the backrest Grafana dashboard

This metric is no longer available when block incremental backups are enabled, which is the recommended method to help reduce backup size

Please indicate what kind of change your PR includes (multiple selections are acceptable):

- [ ] Bugfix
- [ ] Enhancement
- [ ] Breaking Change
- [ ] Documentation

PRs should be against existing issues, so please list each issue using a separate 'closes' line:

closes #459 

If this PR depends on another PR or resolution of another issue, please indicate that here using a separate 'depends' line for each dependency.

depends on #

If you have an **external** dependency (packages, portal updates, etc), add the 'BLOCKED' tag to your PR.


## Testing
*None of the testing listed below is optional.*

- Installation method:  
    - [ ] Binary install from source, version:  
    - [x] OS package repository, distro, and version:  
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [ ] Other:  
- [ ] PostgreSQL, Specify version(s):  
- [ ] docs tested with hugo version(s):  

### Code testing

Have you tested your changes against:
- [x] RedHat/CentOS
- [ ] Ubuntu
- [ ] Not applicable

If your code touches sql_exporter, have you:
- [x] Tested against all versions of PostgreSQL affected
- [x] Ensure that exporter runs with no scrape errors
- [ ] Not applicable

If your code touches node_exporter, have you:
- [ ] Ensure that exporter runs with no scrape errors
- [ ] Not applicable

If your code touches Prometheus, have you:
- [ ] Ensured all configuration changes pass `promtool check config`
- [ ] Ensured all alert rule changes pass `promtool check rules`
- [ ] Prometheus runs without issue
- [ ] Alertmanager runs without issue
- [ ] Not applicable

If your code touches Grafana, have you:
- [x] Ensured Grafana runs without issue
- [x] Ensured relevant dashboards load without issue
- [ ] Not applicable

### Checklist:
- I have made corresponding changes to:  
    - [x] the documentation  
    - [x] the release notes  
    - [ ] the upgrade doc  
