### PR TITLE
fix: fix reserve_pool column name change for show databases

### DIFF
--- a/changelogs/fragments/464.yml
+++ b/changelogs/fragments/464.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - sql_exporter - Create new collections file for pgBouncer 1.24+

--- a/hugo/content/exporter/_index.md
+++ b/hugo/content/exporter/_index.md
@@ -181,7 +181,7 @@ CREATE EXTENSION pg_stat_statements;
 | crunchy_per_db_collector.yml                   | Collection file with general per-database level queries and metrics |
 | crunchy_pg_stat_statements_collector.yml       | Collection file with pg_stat_statements queries and metrics
 | crunchy_pg_stat_statements_reset_collector.yml | Collection file with options to allow resetting of pg_stat_statements metrics |
-| crunchy_pgbouncer_collector_121.yml            | Collection file with pgBouncer queries and metrics for a minimum version of 1.21 |
+| crunchy_pgbouncer_collector_*.yml            | Collection files for pgBouncer queries and metrics. The number suffix on the filename is the minimum version of pgBouncer required for that file. If there is a newer version file available, that one must be used if that version of pgBouncer or greater is running. Example: collector_121.yml requires at least pgBouncer 1.21. But there is also a collector_124.yml file, so if you are running pgBouncer 1.24+, you must use the 124 file. Note that a newer file will only be created if necessary to support changes in the pgBouncer API. |
 
 
 Run the `setup_db.sql` file on all databases that will be monitored by pgMonitor. At minimum this must be at least the global database so the necessary database objects are created. The `pgmonitor-extension` is expected to be available to be installed in the target database(s) when running this file. Note the `setup_db.sql` file is a convenience file and the steps contained within it can be done manually and customized as needed. Note that a default password is not set for the `ccp_monitoring` database role.

--- a/sql_exporter/common/crunchy_pgbouncer_124_collector.yml
+++ b/sql_exporter/common/crunchy_pgbouncer_124_collector.yml
@@ -1,0 +1,199 @@
+collector_name: crunchy_pgbouncer_121
+# Collector for PgBouncer minimum version of 1.21
+
+metrics:
+  - metric_name: ccp_pgbouncer_clients_wait_seconds
+    type: gauge
+    help: "Current waiting time in seconds"
+    values: [wait]
+    key_labels:
+      - database
+      - user
+      - state
+      - application_name
+      - link
+    query_ref: ccp_pgbouncer_clients
+
+
+  - metric_name: ccp_pgbouncer_databases_pool_size
+    type: gauge
+    help: "Maximum number of server connections"
+    values: [pool_size]
+    key_labels:
+      - name
+      - host
+      - port
+      - database
+      - force_user
+      - pool_mode
+    query_ref: ccp_pgbouncer_databases
+  - metric_name: ccp_pgbouncer_databases_min_pool_size
+    type: gauge
+    help: "Minimum number of server connections"
+    values: [min_pool_size]
+    key_labels:
+      - name
+      - host
+      - port
+      - database
+      - force_user
+      - pool_mode
+    query_ref: ccp_pgbouncer_databases
+  - metric_name: ccp_pgbouncer_databases_reserve_pool_size
+    type: gauge
+    help: "Maximum number of additional connections for this database"
+    values: [reserve_pool_size]
+    key_labels:
+      - name
+      - host
+      - port
+      - database
+      - force_user
+      - pool_mode
+    query_ref: ccp_pgbouncer_databases
+  - metric_name: ccp_pgbouncer_databases_max_connections
+    type: gauge
+    help: "Maximum number of allowed connections for this database, as set by max_db_connections, either globally or per database"
+    values: [max_connections]
+    key_labels:
+      - name
+      - host
+      - port
+      - database
+      - force_user
+      - pool_mode
+    query_ref: ccp_pgbouncer_databases
+  - metric_name: ccp_pgbouncer_databases_current_connections
+    type: gauge
+    help: "Current number of connections for this database"
+    values: [current_connections]
+    key_labels:
+      - name
+      - host
+      - port
+      - database
+      - force_user
+      - pool_mode
+    query_ref: ccp_pgbouncer_databases
+  - metric_name: ccp_pgbouncer_databases_paused
+    type: gauge
+    help: "1 if this database is currently paused, else 0"
+    values: [paused]
+    key_labels:
+      - name
+      - host
+      - port
+      - database
+      - force_user
+      - pool_mode
+    query_ref: ccp_pgbouncer_databases
+  - metric_name: ccp_pgbouncer_databases_disabled
+    type: gauge
+    help: "1 if this database is currently disabled, else 0"
+    values: [disabled]
+    key_labels:
+      - name
+      - host
+      - port
+      - database
+      - force_user
+      - pool_mode
+    query_ref: ccp_pgbouncer_databases
+
+
+  - metric_name: ccp_pgbouncer_lists_item_count
+    type: gauge
+    help: "Count of items registered with pgBouncer"
+    values: [items]
+    key_labels:
+      - list
+    query_ref: ccp_pgbouncer_lists
+
+
+  - metric_name: ccp_pgbouncer_pools_client_active
+    type: gauge
+    help: "Client connections that are either linked to server connections or are idle with no queries waiting to be processed"
+    values: [cl_active]
+    key_labels:
+      - database
+      - user
+    query_ref: ccp_pgbouncer_pools
+  - metric_name: ccp_pgbouncer_pools_client_waiting
+    type: gauge
+    help: "Client connections that have sent queries but have not yet got a server connection"
+    values: [cl_waiting]
+    key_labels:
+      - database
+      - user
+    query_ref: ccp_pgbouncer_pools
+  - metric_name: ccp_pgbouncer_pools_server_active
+    type: gauge
+    help: "Server connections that are linked to a client"
+    values: [sv_active]
+    key_labels:
+      - database
+      - user
+    query_ref: ccp_pgbouncer_pools
+  - metric_name: ccp_pgbouncer_pools_server_idle
+    type: gauge
+    help: "Server connections that are unused and immediately usable for client queries"
+    values: [sv_idle]
+    key_labels:
+      - database
+      - user
+    query_ref: ccp_pgbouncer_pools
+  - metric_name: ccp_pgbouncer_pools_server_used
+    type: gauge
+    help: "Server connections that have been idle for more than server_check_delay, so they need server_check_query to run on them before they can be used again"
+    values: [sv_used]
+    key_labels:
+      - database
+      - user
+    query_ref: ccp_pgbouncer_pools
+
+
+  - metric_name: ccp_pgbouncer_servers_close_needed
+    type: gauge
+    help: "1 if the connection will be closed as soon as possible, because a configuration file reload or DNS update changed the connection information or RECONNECT was issued"
+    values: [close_needed]
+    key_labels:
+      - database
+      - user
+      - state
+      - application_name
+      - link
+    query_ref: ccp_pgbouncer_servers
+
+
+########## QUERIES ##########
+queries:
+  - query_name: ccp_pgbouncer_clients
+    no_prepared_statement: true
+    query: |
+      SHOW CLIENTS;
+
+  - query_name: ccp_pgbouncer_databases
+    no_prepared_statement: true
+    query: |
+      SHOW DATABASES;
+
+  - query_name: ccp_pgbouncer_lists
+    no_prepared_statement: true
+    query: |
+      SHOW LISTS;
+
+  - query_name: ccp_pgbouncer_pools
+    no_prepared_statement: true
+    query: |
+      SHOW POOLS;
+
+  - query_name: ccp_pgbouncer_servers
+    no_prepared_statement: true
+    query: |
+      SHOW SERVERS;
+
+# Add later if needed
+#  - query_name: ccp_pgbouncer_stats
+#    no_prepared_statement: true
+#    query: |
+#      SHOW STATS;

--- a/sql_exporter/common/crunchy_pgbouncer_124_collector.yml
+++ b/sql_exporter/common/crunchy_pgbouncer_124_collector.yml
@@ -1,5 +1,5 @@
-collector_name: crunchy_pgbouncer_121
-# Collector for PgBouncer minimum version of 1.21
+collector_name: crunchy_pgbouncer_124
+# Collector for PgBouncer minimum version of 1.24
 
 metrics:
   - metric_name: ccp_pgbouncer_clients_wait_seconds


### PR DESCRIPTION
# Description  

Correct the column name change in `show databases` for `reserve_pool` to `reserve_pool_size`. Create a new collection file for pgbouncer 1.24+ that has that change

Please indicate what kind of change your PR includes (multiple selections are acceptable):

- [x] Bugfix
- [ ] Enhancement
- [ ] Breaking Change
- [ ] Documentation

PRs should be against existing issues, so please list each issue using a separate 'closes' line:

closes #464 

If this PR depends on another PR or resolution of another issue, please indicate that here using a separate 'depends' line for each dependency.

depends on #

If you have an **external** dependency (packages, portal updates, etc), add the 'BLOCKED' tag to your PR.


## Testing
*None of the testing listed below is optional.*

- Installation method:  
    - [ ] Binary install from source, version:  
    - [x] OS package repository, distro, and version:  5.2
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [ ] Other:  
- [ ] PostgreSQL, Specify version(s):  
- [ ] docs tested with hugo version(s):  

### Code testing

Have you tested your changes against:
- [x] RedHat/CentOS
- [ ] Ubuntu
- [ ] Not applicable

If your code touches sql_exporter, have you:
- [x] Tested against all versions of PostgreSQL affected
- [ ] Ensure that exporter runs with no scrape errors
- [ ] Not applicable

If your code touches node_exporter, have you:
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches Prometheus, have you:
- [ ] Ensured all configuration changes pass `promtool check config`
- [ ] Ensured all alert rule changes pass `promtool check rules`
- [ ] Prometheus runs without issue
- [ ] Alertmanager runs without issue
- [x] Not applicable

If your code touches Grafana, have you:
- [ ] Ensured Grafana runs without issue
- [ ] Ensured relevant dashboards load without issue
- [x] Not applicable

### Checklist:
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [x] the release notes  
    - [x] the upgrade doc  
