### PR TITLE
Update containers postgresql_details.json dashboard to use pgMonitor …

### DIFF
--- a/changelogs/fragments/470-containers-dashboard-updates.yml
+++ b/changelogs/fragments/470-containers-dashboard-updates.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Updated containers dashboards to use latest ccp metrics in v5.2.1
+  - Add pgBouncer dashboard to containers folder

--- a/grafana/containers/pgbouncer_direct.json
+++ b/grafana/containers/pgbouncer_direct.json
@@ -1,0 +1,710 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "PROMETHEUS",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "7.4.5"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": false,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+      "vendor=crunchydata"
+      ],
+      "title": "",
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+    "datasource": "PROMETHEUS",
+    "fieldConfig": {
+      "defaults": {
+      "color": {
+        "mode": "palette-classic"
+      },
+      "custom": {
+        "axisBorderShow": false,
+        "axisCenteredZero": false,
+        "axisColorMode": "text",
+        "axisLabel": "",
+        "axisPlacement": "auto",
+        "barAlignment": 0,
+        "drawStyle": "line",
+        "fillOpacity": 10,
+        "gradientMode": "none",
+        "hideFrom": {
+        "legend": false,
+        "tooltip": false,
+        "viz": false
+        },
+        "insertNulls": false,
+        "lineInterpolation": "linear",
+        "lineWidth": 1,
+        "pointSize": 5,
+        "scaleDistribution": {
+        "type": "linear"
+        },
+        "showPoints": "never",
+        "spanNulls": false,
+        "stacking": {
+        "group": "A",
+        "mode": "none"
+        },
+        "thresholdsStyle": {
+        "mode": "off"
+        }
+      },
+      "links": [],
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+        {
+          "color": "green",
+          "value": null
+        },
+        {
+          "color": "red",
+          "value": 80
+        }
+        ]
+      },
+      "unit": "short"
+      },
+      "overrides": []
+    },
+    "gridPos": {
+      "h": 10,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    "id": 2,
+    "options": {
+      "legend": {
+      "calcs": [],
+      "displayMode": "list",
+      "placement": "bottom",
+      "showLegend": true
+      },
+      "tooltip": {
+      "mode": "multi",
+      "sort": "none"
+      }
+    },
+    "pluginVersion": "9.5.15",
+    "targets": [
+      {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ccp_datasource}"
+      },
+      "editorMode": "code",
+      "expr": "sum(ccp_pgbouncer_pools_client_active{cluster_name=~\"[[cluster_name]]\",pod=~\"[[pgbnode]]\"})",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "client_active",
+      "range": true,
+      "refId": "A"
+      },
+      {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ccp_datasource}"
+      },
+      "editorMode": "code",
+      "expr": "sum(ccp_pgbouncer_pools_client_waiting{cluster_name=~\"[[cluster_name]]\",pod=~\"[[pgbnode]]\"})",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "client_waiting",
+      "range": true,
+      "refId": "B"
+      },
+      {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ccp_datasource}"
+      },
+      "editorMode": "code",
+      "expr": "sum(ccp_pgbouncer_pools_server_active{cluster_name=~\"[[cluster_name]]\",pod=~\"[[pgbnode]]\"})",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "server_active",
+      "range": true,
+      "refId": "C"
+      },
+      {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ccp_datasource}"
+      },
+      "editorMode": "code",
+      "expr": "sum(ccp_pgbouncer_pools_server_idle{cluster_name=~\"[[cluster_name]]\",pod=~\"[[pgbnode]]\"})",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "server_idle",
+      "range": true,
+      "refId": "D"
+      },
+      {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ccp_datasource}"
+      },
+      "editorMode": "code",
+      "expr": "sum(ccp_pgbouncer_pools_server_used{cluster_name=~\"[[cluster_name]]\",pod=~\"[[pgbnode]]\"})",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "server_used",
+      "range": true,
+      "refId": "E"
+      }
+    ],
+    "title": "PGBouncer Total State Counts",
+    "type": "timeseries"
+    },
+    {
+    "datasource": "PROMETHEUS",
+    "fieldConfig": {
+      "defaults": {
+      "color": {
+        "mode": "palette-classic"
+      },
+      "custom": {
+        "axisBorderShow": false,
+        "axisCenteredZero": false,
+        "axisColorMode": "text",
+        "axisLabel": "",
+        "axisPlacement": "auto",
+        "barAlignment": 0,
+        "drawStyle": "line",
+        "fillOpacity": 10,
+        "gradientMode": "none",
+        "hideFrom": {
+        "legend": false,
+        "tooltip": false,
+        "viz": false
+        },
+        "insertNulls": false,
+        "lineInterpolation": "linear",
+        "lineWidth": 1,
+        "pointSize": 5,
+        "scaleDistribution": {
+        "type": "linear"
+        },
+        "showPoints": "never",
+        "spanNulls": false,
+        "stacking": {
+        "group": "A",
+        "mode": "none"
+        },
+        "thresholdsStyle": {
+        "mode": "off"
+        }
+      },
+      "links": [],
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+        {
+          "color": "green",
+          "value": null
+        },
+        {
+          "color": "red",
+          "value": 80
+        }
+        ]
+      },
+      "unit": "short"
+      },
+      "overrides": []
+    },
+    "gridPos": {
+      "h": 10,
+      "w": 12,
+      "x": 12,
+      "y": 0
+    },
+    "id": 4,
+    "options": {
+      "legend": {
+      "calcs": [],
+      "displayMode": "list",
+      "placement": "bottom",
+      "showLegend": true
+      },
+      "tooltip": {
+      "mode": "multi",
+      "sort": "none"
+      }
+    },
+    "pluginVersion": "9.5.15",
+    "targets": [
+      {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ccp_datasource}"
+      },
+      "editorMode": "code",
+      "expr": "ccp_pgbouncer_lists_item_count{cluster_name=~\"[[cluster_name]]\",pod=~\"[[pgbnode]]\"}",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "{{list}}",
+      "range": true,
+      "refId": "A"
+      }
+    ],
+    "title": "PGBouncer Total Item Counts",
+    "type": "timeseries"
+    },
+    {
+    "datasource": "PROMETHEUS",
+    "fieldConfig": {
+      "defaults": {
+      "color": {
+        "mode": "palette-classic"
+      },
+      "custom": {
+        "axisBorderShow": false,
+        "axisCenteredZero": false,
+        "axisColorMode": "text",
+        "axisLabel": "",
+        "axisPlacement": "auto",
+        "barAlignment": 0,
+        "drawStyle": "line",
+        "fillOpacity": 10,
+        "gradientMode": "none",
+        "hideFrom": {
+        "legend": false,
+        "tooltip": false,
+        "viz": false
+        },
+        "insertNulls": false,
+        "lineInterpolation": "linear",
+        "lineWidth": 1,
+        "pointSize": 5,
+        "scaleDistribution": {
+        "type": "linear"
+        },
+        "showPoints": "never",
+        "spanNulls": false,
+        "stacking": {
+        "group": "A",
+        "mode": "none"
+        },
+        "thresholdsStyle": {
+        "mode": "off"
+        }
+      },
+      "links": [],
+      "mappings": [],
+      "max": 1,
+      "min": 0,
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+        {
+          "color": "green",
+          "value": null
+        },
+        {
+          "color": "red",
+          "value": 80
+        }
+        ]
+      },
+      "unit": "percentunit"
+      },
+      "overrides": []
+    },
+    "gridPos": {
+      "h": 10,
+      "w": 8,
+      "x": 0,
+      "y": 10
+    },
+    "id": 6,
+    "options": {
+      "legend": {
+      "calcs": [],
+      "displayMode": "list",
+      "placement": "bottom",
+      "showLegend": true
+      },
+      "tooltip": {
+      "mode": "multi",
+      "sort": "none"
+      }
+    },
+    "pluginVersion": "9.5.15",
+    "targets": [
+      {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ccp_datasource}"
+      },
+      "editorMode": "code",
+      "expr": "ccp_pgbouncer_databases_current_connections{cluster_name=~\"[[cluster_name]]\", pod=~\"[[pgbnode]]\", name=~\"[[pool]]\"} / ccp_pgbouncer_databases_pool_size{cluster_name=~\"[[cluster_name]]\", pod=~\"[[pgbnode]]\", name=~\"[[pool]]\"}",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "{{name}}",
+      "range": true,
+      "refId": "A"
+      }
+    ],
+    "title": "Connection % Used Per Pool ([[pool]])",
+    "type": "timeseries"
+    },
+    {
+    "datasource": "PROMETHEUS",
+    "description": "",
+    "fieldConfig": {
+      "defaults": {
+      "color": {
+        "mode": "palette-classic"
+      },
+      "custom": {
+        "axisBorderShow": false,
+        "axisCenteredZero": false,
+        "axisColorMode": "text",
+        "axisLabel": "",
+        "axisPlacement": "auto",
+        "barAlignment": 0,
+        "drawStyle": "line",
+        "fillOpacity": 10,
+        "gradientMode": "none",
+        "hideFrom": {
+        "legend": false,
+        "tooltip": false,
+        "viz": false
+        },
+        "insertNulls": false,
+        "lineInterpolation": "linear",
+        "lineWidth": 1,
+        "pointSize": 5,
+        "scaleDistribution": {
+        "type": "linear"
+        },
+        "showPoints": "never",
+        "spanNulls": false,
+        "stacking": {
+        "group": "A",
+        "mode": "none"
+        },
+        "thresholdsStyle": {
+        "mode": "off"
+        }
+      },
+      "links": [],
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+        {
+          "color": "green",
+          "value": null
+        },
+        {
+          "color": "red",
+          "value": 80
+        }
+        ]
+      },
+      "unit": "short"
+      },
+      "overrides": []
+    },
+    "gridPos": {
+      "h": 10,
+      "w": 8,
+      "x": 8,
+      "y": 10
+    },
+    "id": 8,
+    "options": {
+      "legend": {
+      "calcs": [],
+      "displayMode": "list",
+      "placement": "bottom",
+      "showLegend": true
+      },
+      "tooltip": {
+      "mode": "multi",
+      "sort": "none"
+      }
+    },
+    "pluginVersion": "9.5.15",
+    "targets": [
+      {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ccp_datasource}"
+      },
+      "editorMode": "code",
+      "expr": "sum(ccp_pgbouncer_clients_wait_seconds{cluster_name=~\"[[cluster_name]]\",pod=~\"[[pgbnode]]\", database=~\"[[pool]]\"}) by (pool,state)",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "{{pool}}",
+      "range": true,
+      "refId": "A"
+      }
+    ],
+    "title": "Client Connection State Counts Per Pool  ([[pool]])",
+    "type": "timeseries"
+    },
+    {
+    "datasource": "PROMETHEUS",
+    "fieldConfig": {
+      "defaults": {
+      "color": {
+        "mode": "palette-classic"
+      },
+      "custom": {
+        "axisBorderShow": false,
+        "axisCenteredZero": false,
+        "axisColorMode": "text",
+        "axisLabel": "",
+        "axisPlacement": "auto",
+        "barAlignment": 0,
+        "drawStyle": "line",
+        "fillOpacity": 10,
+        "gradientMode": "none",
+        "hideFrom": {
+        "legend": false,
+        "tooltip": false,
+        "viz": false
+        },
+        "insertNulls": false,
+        "lineInterpolation": "linear",
+        "lineWidth": 1,
+        "pointSize": 5,
+        "scaleDistribution": {
+        "type": "linear"
+        },
+        "showPoints": "never",
+        "spanNulls": false,
+        "stacking": {
+        "group": "A",
+        "mode": "none"
+        },
+        "thresholdsStyle": {
+        "mode": "off"
+        }
+      },
+      "links": [],
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+        {
+          "color": "green",
+          "value": null
+        },
+        {
+          "color": "red",
+          "value": 80
+        }
+        ]
+      },
+      "unit": "short"
+      },
+      "overrides": []
+    },
+    "gridPos": {
+      "h": 10,
+      "w": 8,
+      "x": 16,
+      "y": 10
+    },
+    "id": 10,
+    "options": {
+      "legend": {
+      "calcs": [],
+      "displayMode": "list",
+      "placement": "bottom",
+      "showLegend": true
+      },
+      "tooltip": {
+      "mode": "multi",
+      "sort": "none"
+      }
+    },
+    "pluginVersion": "9.5.15",
+    "targets": [
+      {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ccp_datasource}"
+      },
+      "editorMode": "code",
+      "expr": "sum(ccp_pgbouncer_servers_close_needed{cluster_name=~\"[[cluster_name]]\",pod=~\"[[pgbnode]]\", database=~\"[[pool]]\"}) by (state)",
+      "format": "time_series",
+      "intervalFactor": 1,
+      "legendFormat": "__auto",
+      "range": true,
+      "refId": "A"
+      }
+    ],
+    "title": "Server Connection State Counts Per Pool  ([[pool]])",
+    "type": "timeseries"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "vendor=crunchydata"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": "PROMETHEUS",
+        "definition": "label_values(up{exp_type='pgbouncer'},cluster_name)",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "cluster_name",
+        "options": [],
+        "query": {
+          "query": "label_values(up{exp_type='pgbouncer'},cluster_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {},
+        "datasource": "PROMETHEUS",
+        "definition": "label_values(up{exp_type='pgbouncer'},pod)",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "pgbnode",
+        "options": [],
+        "query": {
+          "query": "label_values(up{exp_type='pgbouncer'},pod)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "PROMETHEUS",
+        "definition": "label_values(ccp_pgbouncer_databases_pool_size{cluster_name=\"[[cluster_name]]\", pod=\"[[pgbnode]]\"},name)",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "pool",
+        "options": [],
+        "query": {
+          "query": "label_values(ccp_pgbouncer_databases_pool_size{cluster_name=\"[[cluster_name]]\", pod=\"[[pgbnode]]\"},name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "time_options": [
+    "5m",
+    "15m",
+    "1h",
+    "6h",
+    "12h",
+    "24h",
+    "2d",
+    "7d",
+    "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "PGBouncer",
+  "uid": "a7ff3775-37c9-4072-b0bc-1292f5c5841b",
+  "version": 1
+}

--- a/grafana/containers/pod_details.json
+++ b/grafana/containers/pod_details.json
@@ -70,8 +70,8 @@
           "mappings": [
             {
               "options": {
-                "0": {
-                  "index": 0,
+                "2": {
+                  "index": 2,
                   "text": "Primary"
                 },
                 "1": {
@@ -115,7 +115,7 @@
           "datasource": "PROMETHEUS",
           "editorMode": "code",
           "exemplar": false,
-          "expr": "pg_replication_is_replica{pod=\"[[pod]]\", pg_cluster=\"[[cluster]]\"}",
+          "expr": "ccp_is_in_recovery_status{pod=\"[[pod]]\", pg_cluster=\"[[cluster]]\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -1196,7 +1196,7 @@
         "allValue": null,
         "current": {},
         "datasource": "PROMETHEUS",
-        "definition": "label_values({pg_cluster=\"[[cluster]]\"},pod)",
+        "definition": "label_values({pg_cluster=\"[[cluster]]\", exp_type!=\"pgbouncer\"},pod)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1206,7 +1206,7 @@
         "name": "pod",
         "options": [],
         "query": {
-          "query": "label_values({pg_cluster=\"[[cluster]]\"},pod)",
+          "query": "label_values({pg_cluster=\"[[cluster]]\", exp_type!=\"pgbouncer\"},pod)",
           "refId": "PROMETHEUS-pod-Variable-Query"
         },
         "refresh": 1,

--- a/grafana/containers/postgresql_details.json
+++ b/grafana/containers/postgresql_details.json
@@ -231,7 +231,7 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "sum(pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\", state=\"active\"})*100 /sum(pg_settings_max_connections{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})",
+          "expr": "sum(pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\", state=\"active\"})*100 /sum(pg_settings_max_connections{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}) or sum(ccp_pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\", state=\"active\"})*100 /sum(ccp_connection_stats_max_connections{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -313,7 +313,7 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "sum(pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"idle in transaction\"})/sum(pg_settings_max_connections{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})",
+          "expr": "sum(pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"idle in transaction\"})/sum(pg_settings_max_connections{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}) or sum(ccp_pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"idle in transaction\"})/sum(ccp_connection_stats_max_connections{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -472,7 +472,7 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "sum(pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"idle\"})*100/sum(pg_settings_max_connections{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})",
+          "expr": "sum(pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"idle\"})*100/sum(pg_settings_max_connections{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}) or sum(ccp_pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"idle\"})*100/sum(ccp_connection_stats_max_connections{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -816,7 +816,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (state) (pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"idle\"})",
+          "expr": "sum by (state) (pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"idle\"}) or sum by (state) (ccp_pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"idle\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -827,7 +827,7 @@
           "step": 2
         },
         {
-          "expr": "sum by (state) (pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"idle in transaction\"})",
+          "expr": "sum by (state) (pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"idle in transaction\"}) or sum by (state) (ccp_pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"idle in transaction\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -835,7 +835,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum by (state) (pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"active\"})",
+          "expr": "sum by (state) (pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"active\"}) or sum by (state) (ccp_pg_stat_activity_count{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\",datname=~\"[[datname]]\",state=\"active\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "active",
@@ -1696,34 +1696,34 @@
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Allocated",
-          "metric": "pg_stat_bgwriter_buffers_alloc",
+          "metric": "ccp_stat_bgwriter_buffers_alloc",
           "refId": "A",
           "step": 2
         },
         {
-          "expr": "sum(ccp_stat_bgwriter_buffers_backend{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})",
+          "expr": "sum(ccp_stat_io_bgwriter_writes{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}) or sum(ccp_stat_bgwriter_buffers_backend{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "Backend",
-          "metric": "pg_stat_bgwriter_buffers_backend",
+          "legendFormat": "Writes",
+          "metric": "ccp_stat_io_bgwriter_writes",
           "refId": "B",
           "step": 2
         },
         {
-          "expr": "sum(ccp_stat_bgwriter_buffers_backend_fsync{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})",
+          "expr": "sum(ccp_stat_io_bgwriter_fsyncs{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}) or sum(ccp_stat_bgwriter_buffers_backend_fsync{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "FSync",
-          "metric": "pg_stat_bgwriter_buffers_backend_fsync",
+          "metric": "ccp_stat_io_bgwriter_fsyncs",
           "refId": "C",
           "step": 2
         },
         {
-          "expr": "sum(ccp_stat_bgwriter_buffers_checkpoint{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})",
+          "expr": "sum(ccp_stat_checkpointer_buffers_written{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"}) or sum(ccp_stat_bgwriter_buffers_checkpoint{pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "CheckPoint",
-          "metric": "pg_stat_bgwriter_buffers_checkpoint",
+          "metric": "ccp_stat_checkpointer_buffers_written",
           "refId": "D",
           "step": 2
         },
@@ -1732,7 +1732,7 @@
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Clean",
-          "metric": "pg_stat_bgwriter_buffers_clean",
+          "metric": "ccp_stat_bgwriter_buffers_clean",
           "refId": "E",
           "step": 2
         }
@@ -2071,7 +2071,7 @@
         "allValue": ".*",
         "current": {},
         "datasource": "PROMETHEUS",
-        "definition": "label_values({pg_cluster=\"[[cluster]]\"},pod)",
+        "definition": "label_values({pg_cluster=\"[[cluster]]\", exp_type!=\"pgbouncer\"},pod)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2081,7 +2081,7 @@
         "name": "pod",
         "options": [],
         "query": {
-          "query": "label_values({pg_cluster=\"[[cluster]]\"},pod)",
+          "query": "label_values({pg_cluster=\"[[cluster]]\", exp_type!=\"pgbouncer\"},pod)",
           "refId": "PROMETHEUS-pod-Variable-Query"
         },
         "refresh": 1,

--- a/grafana/containers/postgresql_overview.json
+++ b/grafana/containers/postgresql_overview.json
@@ -163,7 +163,7 @@
       "targets": [
         {
           "$hashKey": "object:243",
-          "expr": "sum(pg_up{pg_cluster=~\"$cluster\"})*100+sum(ccp_is_in_recovery_status{pg_cluster=~\"$cluster\"})",
+          "expr": "sum(pg_up{pg_cluster=~\"$cluster\"})*100+sum(ccp_is_in_recovery_status{pg_cluster=~\"$cluster\"}) or sum(up{pg_cluster=~\"$cluster\"})*100+sum(ccp_is_in_recovery_status{pg_cluster=~\"$cluster\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,

--- a/grafana/containers/postgresql_service_health.json
+++ b/grafana/containers/postgresql_service_health.json
@@ -600,7 +600,7 @@
         "allValue": null,
         "current": {},
         "datasource": "PROMETHEUS",
-        "definition": "label_values({pg_cluster=\"[[cluster]]\"},role)",
+        "definition": "label_values({pg_cluster=\"[[cluster]]\", exp_type!=\"pgbouncer\"},role)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -610,7 +610,7 @@
         "name": "role",
         "options": [],
         "query": {
-          "query": "label_values({pg_cluster=\"[[cluster]]\"},role)",
+          "query": "label_values({pg_cluster=\"[[cluster]]\", exp_type!=\"pgbouncer\"},role)",
           "refId": "PROMETHEUS-role-Variable-Query"
         },
         "refresh": 1,

--- a/grafana/containers/prometheus_alerts.json
+++ b/grafana/containers/prometheus_alerts.json
@@ -136,7 +136,7 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "count(count by (kubernetes_namespace) (pg_up))",
+          "expr": "count(count by (kubernetes_namespace) (pg_up)) or count(count by (kubernetes_namespace) (up))",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -208,7 +208,7 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "count(count by (pg_cluster) (pg_up))",
+          "expr": "count(count by (pg_cluster) (pg_up)) or count(count by (pg_cluster) (up))",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -280,7 +280,7 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "count(pg_up)",
+          "expr": "count(pg_up) or count(up)",
           "format": "time_series",
           "instant": true,
           "interval": "",

--- a/grafana/containers/query_statistics.json
+++ b/grafana/containers/query_statistics.json
@@ -1068,7 +1068,7 @@
         "allValue": null,
         "current": {},
         "datasource": "PROMETHEUS",
-        "definition": "label_values({pg_cluster=\"[[cluster]]\"},role)",
+        "definition": "label_values({pg_cluster=\"[[cluster]]\", exp_type!=\"pgbouncer\"},role)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1078,7 +1078,7 @@
         "name": "role",
         "options": [],
         "query": {
-          "query": "label_values({pg_cluster=\"[[cluster]]\"},role)",
+          "query": "label_values({pg_cluster=\"[[cluster]]\", exp_type!=\"pgbouncer\"},role)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,


### PR DESCRIPTION
…v5.2.1 metrics.

Update other containers dashboards to use ccp metrics and maintain compatibility with postgres_exporter metrics. Add pgBouncer dashboard.
Ignore pgBouncer in non-pgBouncer dashboards.

# Description  

*Please fill this template out fully; failure to do so can result in rejection of your PR.*

Please describe the changes made by your PR. This description should be at a high-level but detailed enough that a reviewer understands the scope of the fix or enhancement and can easily judge the PRs validity at addressing the stated issue/feature. Please fully describe any new or changed feature and whether said change is user-facing or not:

The OpenTelemetry metrics feature in CPK is designed to use the latest available ccp metrics in pgMonitor. This PR updates the containers dashboards to use the metrics while also maintaining compatibility with postgres_exporter metrics. This PR also adds a pgBouncer dedicated dashboard and ignores pgBouncer pods in other non-pgBouncer specific dashboards.

Please indicate what kind of change your PR includes (multiple selections are acceptable):

- [ ] Bugfix
- [x] Enhancement
- [ ] Breaking Change
- [ ] Documentation

PRs should be against existing issues, so please list each issue using a separate 'closes' line:

closes #469 

If this PR depends on another PR or resolution of another issue, please indicate that here using a separate 'depends' line for each dependency.

N/A

If you have an **external** dependency (packages, portal updates, etc), add the 'BLOCKED' tag to your PR.


## Testing
*None of the testing listed below is optional.*

- Installation method:  
    - [ ] Binary install from source, version:  
    - [ ] OS package repository, distro, and version:  
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [x] Other: CPK 
- [ ] PostgreSQL, Specify version(s):  
- [ ] docs tested with hugo version(s):  

### Code testing

Have you tested your changes against:
- [ ] RedHat/CentOS
- [ ] Ubuntu
- [x] Not applicable

If your code touches sql_exporter, have you:
- [ ] Tested against all versions of PostgreSQL affected
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches node_exporter, have you:
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches Prometheus, have you:
- [ ] Ensured all configuration changes pass `promtool check config`
- [ ] Ensured all alert rule changes pass `promtool check rules`
- [ ] Prometheus runs without issue
- [ ] Alertmanager runs without issue
- [x] Not applicable

If your code touches Grafana, have you:
- [x] Ensured Grafana runs without issue
- [x] Ensured relevant dashboards load without issue
- [ ] Not applicable

### Checklist:
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [x] the release notes  
    - [ ] the upgrade doc  
