### PR TITLE
feat(container): make dashboard portable and ready to use

### DIFF
--- a/grafana/containers/pgbackrest.json
+++ b/grafana/containers/pgbackrest.json
@@ -68,7 +68,7 @@
   ],
   "panels": [
     {
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -139,7 +139,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -267,7 +267,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -390,7 +390,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -517,7 +517,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -637,7 +637,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "PROMETHEUS",
+        "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values(pg_cluster)",
         "description": null,
         "error": null,

--- a/grafana/containers/pgbouncer_direct.json
+++ b/grafana/containers/pgbouncer_direct.json
@@ -61,7 +61,7 @@
   ],
   "panels": [
     {
-    "datasource": "PROMETHEUS",
+    "datasource": "${DS_PROMETHEUS}",
     "fieldConfig": {
       "defaults": {
       "color": {
@@ -209,7 +209,7 @@
     "type": "timeseries"
     },
     {
-    "datasource": "PROMETHEUS",
+    "datasource": "${DS_PROMETHEUS}",
     "fieldConfig": {
       "defaults": {
       "color": {
@@ -305,7 +305,7 @@
     "type": "timeseries"
     },
     {
-    "datasource": "PROMETHEUS",
+    "datasource": "${DS_PROMETHEUS}",
     "fieldConfig": {
       "defaults": {
       "color": {
@@ -403,7 +403,7 @@
     "type": "timeseries"
     },
     {
-    "datasource": "PROMETHEUS",
+    "datasource": "${DS_PROMETHEUS}",
     "description": "",
     "fieldConfig": {
       "defaults": {
@@ -500,7 +500,7 @@
     "type": "timeseries"
     },
     {
-    "datasource": "PROMETHEUS",
+    "datasource": "${DS_PROMETHEUS}",
     "fieldConfig": {
       "defaults": {
       "color": {
@@ -606,7 +606,7 @@
     "list": [
       {
         "current": {},
-        "datasource": "PROMETHEUS",
+        "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values(up{exp_type='pgbouncer'},cluster_name)",
         "hide": 0,
         "includeAll": false,
@@ -630,7 +630,7 @@
       },
       {
         "current": {},
-        "datasource": "PROMETHEUS",
+        "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values(up{exp_type='pgbouncer'},pod)",
         "hide": 0,
         "includeAll": true,
@@ -662,7 +662,7 @@
             "$__all"
           ]
         },
-        "datasource": "PROMETHEUS",
+        "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values(ccp_pgbouncer_databases_pool_size{cluster_name=\"[[cluster_name]]\", pod=\"[[pgbnode]]\"},name)",
         "hide": 0,
         "includeAll": true,

--- a/grafana/containers/pod_details.json
+++ b/grafana/containers/pod_details.json
@@ -60,7 +60,7 @@
   ],
   "panels": [
     {
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -112,7 +112,7 @@
       "pluginVersion": "9.2.20",
       "targets": [
         {
-          "datasource": "PROMETHEUS",
+          "datasource": "${DS_PROMETHEUS}",
           "editorMode": "code",
           "exemplar": false,
           "expr": "ccp_is_in_recovery_status{pod=\"[[pod]]\", pg_cluster=\"[[cluster]]\"}",
@@ -136,7 +136,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "color": {},
@@ -261,7 +261,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "color": {},
@@ -390,7 +390,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -523,7 +523,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -635,7 +635,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -742,7 +742,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -858,7 +858,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1029,7 +1029,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1168,7 +1168,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "PROMETHEUS",
+        "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values(pg_cluster)",
         "description": null,
         "error": null,
@@ -1195,7 +1195,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "PROMETHEUS",
+        "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values({pg_cluster=\"[[cluster]]\", exp_type!=\"pgbouncer\"},pod)",
         "description": null,
         "error": null,

--- a/grafana/containers/postgresql_details.json
+++ b/grafana/containers/postgresql_details.json
@@ -75,7 +75,7 @@
   "panels": [
     {
       "cacheTimeout": null,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -166,7 +166,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -248,7 +248,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -327,7 +327,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -407,7 +407,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -488,7 +488,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -569,7 +569,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -654,7 +654,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -769,7 +769,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -888,7 +888,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -999,7 +999,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1124,7 +1124,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1268,7 +1268,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1370,7 +1370,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1522,7 +1522,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1644,7 +1644,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1783,7 +1783,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1930,7 +1930,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -2042,7 +2042,7 @@
         "allFormat": "glob",
         "allValue": null,
         "current": {},
-        "datasource": "PROMETHEUS",
+        "datasource": "${DS_PROMETHEUS}",
         "definition": "",
         "description": null,
         "error": null,
@@ -2070,7 +2070,7 @@
         "allFormat": "glob",
         "allValue": ".*",
         "current": {},
-        "datasource": "PROMETHEUS",
+        "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values({pg_cluster=\"[[cluster]]\", exp_type!=\"pgbouncer\"},pod)",
         "description": null,
         "error": null,
@@ -2098,7 +2098,7 @@
         "allFormat": "glob",
         "allValue": ".*",
         "current": {},
-        "datasource": "PROMETHEUS",
+        "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values({pg_cluster=\"[[cluster]]\",pod=~\"[[pod]]\"},dbname)",
         "description": null,
         "error": null,

--- a/grafana/containers/postgresql_overview.json
+++ b/grafana/containers/postgresql_overview.json
@@ -51,7 +51,7 @@
   "panels": [
     {
       "cacheTimeout": null,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -187,7 +187,7 @@
         "allFormat": "glob",
         "allValue": null,
         "current": {},
-        "datasource": "PROMETHEUS",
+        "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values(pg_cluster)",
         "description": null,
         "error": null,

--- a/grafana/containers/postgresql_service_health.json
+++ b/grafana/containers/postgresql_service_health.json
@@ -66,7 +66,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -179,7 +179,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -299,7 +299,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "description": "Errors",
       "fieldConfig": {
         "defaults": {
@@ -440,7 +440,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -572,7 +572,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "PROMETHEUS",
+        "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values(pg_cluster)",
         "description": null,
         "error": null,
@@ -599,7 +599,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "PROMETHEUS",
+        "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values({pg_cluster=\"[[cluster]]\", exp_type!=\"pgbouncer\"},role)",
         "description": null,
         "error": null,

--- a/grafana/containers/prometheus_alerts.json
+++ b/grafana/containers/prometheus_alerts.json
@@ -65,7 +65,7 @@
   "panels": [
     {
       "collapsed": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -80,7 +80,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -150,7 +150,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -222,7 +222,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -294,7 +294,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -309,7 +309,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -406,7 +406,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -475,7 +475,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -545,7 +545,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -559,7 +559,7 @@
       "type": "row"
     },
     {
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -753,7 +753,7 @@
       "type": "table"
     },
     {
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/containers/query_statistics.json
+++ b/grafana/containers/query_statistics.json
@@ -71,7 +71,7 @@
   ],
   "panels": [
     {
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -125,7 +125,7 @@
       "type": "stat"
     },
     {
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -180,7 +180,7 @@
       "type": "stat"
     },
     {
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -237,7 +237,7 @@
       "type": "stat"
     },
     {
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -298,7 +298,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -393,7 +393,7 @@
       }
     },
     {
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -569,7 +569,7 @@
       "type": "table"
     },
     {
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -745,7 +745,7 @@
       "type": "table"
     },
     {
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -919,7 +919,7 @@
       "type": "table"
     },
     {
-      "datasource": "PROMETHEUS",
+      "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -987,7 +987,7 @@
       "pluginVersion": "8.5.15",
       "targets": [
         {
-          "datasource": "PROMETHEUS",
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "ccp_pg_stat_statements_top_wal_bytes{pg_cluster=\"[[cluster]]\", dbname=~\"[[dbname]]\", role=\"[[role]]\"}",
           "format": "table",
           "instant": true,
@@ -1040,7 +1040,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "PROMETHEUS",
+        "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values(pg_cluster)",
         "description": null,
         "error": null,
@@ -1067,7 +1067,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "PROMETHEUS",
+        "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values({pg_cluster=\"[[cluster]]\", exp_type!=\"pgbouncer\"},role)",
         "description": null,
         "error": null,
@@ -1094,7 +1094,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "PROMETHEUS",
+        "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values(ccp_database_size_bytes{pg_cluster=\"[[cluster]]\"},dbname)",
         "description": null,
         "error": null,
@@ -1121,7 +1121,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "PROMETHEUS",
+        "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values(ccp_pg_stat_statements_total_calls_count{pg_cluster=\"[[cluster]]\", dbname=~\"[[dbname]]\"},exported_role)",
         "description": null,
         "error": null,

--- a/prometheus/containers/crunchy-prometheus.yml.containers
+++ b/prometheus/containers/crunchy-prometheus.yml.containers
@@ -41,7 +41,7 @@ scrape_configs:
   # Convert postgres-operator.crunchydata.com/role to role
   - source_labels: [__meta_kubernetes_pod_label_postgres_operator_crunchydata_com_role]
     target_label: role
-  #  Concert cluster name to cluster_name
+  #  Convert cluster name to cluster_name
   - sourceLabels: [ __meta_kubernetes_pod_label_postgres_operator_crunchydata_com_cluster ]
     targetLabel: cluster_name
 

--- a/prometheus/containers/crunchy-prometheus.yml.containers
+++ b/prometheus/containers/crunchy-prometheus.yml.containers
@@ -41,6 +41,9 @@ scrape_configs:
   # Convert postgres-operator.crunchydata.com/role to role
   - source_labels: [__meta_kubernetes_pod_label_postgres_operator_crunchydata_com_role]
     target_label: role
+  #  Concert cluster name to cluster_name
+  - sourceLabels: [ __meta_kubernetes_pod_label_postgres_operator_crunchydata_com_cluster ]
+    targetLabel: cluster_name
 
 - job_name: 'crunchy-postgres-exporter-v4'
   kubernetes_sd_configs:


### PR DESCRIPTION
# Description  

Please describe the changes made by your PR. This description should be at a high-level but detailed enough that a reviewer understands the scope of the fix or enhancement and can easily judge the PRs validity at addressing the stated issue/feature. Please fully describe any new or changed feature and whether said change is user-facing or not:


- Fix missing cluster_name relabel configuration for Crunchy containers (used by many dashboards)
- Replaced all hardcoded datasource references with the template variable 

 ## Benefits

- Dashboards now work with any Prometheus datasource name
- Easier import process - users can map to their existing datasources
- Follows Grafana best practices for reusable dashboards
- Maintains full backward compatibility

Please indicate what kind of change your PR includes (multiple selections are acceptable):

- [x] Bugfix
- [x] Enhancement
- [ ] Breaking Change
- [ ] Documentation

PRs should be against existing issues, so please list each issue using a separate 'closes' line:

closes https://github.com/CrunchyData/pgmonitor/issues/482


If you have an **external** dependency (packages, portal updates, etc), add the 'BLOCKED' tag to your PR.


## Testing
*None of the testing listed below is optional.*

Tested with IAC configurations and manually over my grafana instance (import + datasource selected after import)

<details>
<summary>IAC method</summary>

```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

resources:
  #   # INFO:https://github.com/CrunchyData/postgres-operator-examples/pull/285
  #   - https://github.com/bilbof/postgres-operator-examples/kustomize/monitoring/grafana/dashboards?ref=main
  - ./dashboards.yaml
  - ./podmonitor.yaml

configMapGenerator:
  - name: grafana-dashboards
    files:
      - https://raw.githubusercontent.com/DrummyFloyd/pgmonitor/refs/heads/fix-uid-prom/grafana/containers/pgbackrest.json
      - https://raw.githubusercontent.com/DrummyFloyd/pgmonitor/refs/heads/fix-uid-prom/grafana/containers/pgbouncer_direct.json
      - https://raw.githubusercontent.com/DrummyFloyd/pgmonitor/refs/heads/fix-uid-prom/grafana/containers/pod_details.json
      - https://raw.githubusercontent.com/DrummyFloyd/pgmonitor/refs/heads/fix-uid-prom/grafana/containers/postgresql_details.json
      - https://raw.githubusercontent.com/DrummyFloyd/pgmonitor/refs/heads/fix-uid-prom/grafana/containers/postgresql_overview.json
      - https://raw.githubusercontent.com/DrummyFloyd/pgmonitor/refs/heads/fix-uid-prom/grafana/containers/postgresql_service_health.json
      - https://raw.githubusercontent.com/DrummyFloyd/pgmonitor/refs/heads/fix-uid-prom/grafana/containers/query_statistics.json
generatorOptions:
  disableNameSuffixHash: true
```

```yaml
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaDashboard
metadata:
  name: pgbackrest
spec:
  allowCrossNamespaceImport: true
  instanceSelector:
    matchLabels:
      grafana: "home"
  folder: Databases
  resyncPeriod: 10m
  configMapRef:
    name: grafana-dashboards
    key: pgbackrest.json
  datasources:
    - inputName: "DS_PROMETHEUS"
      datasourceName: "prometheus"
---
# PGBouncer Direct Dashboard
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaDashboard
metadata:
  name: pgbouncer-direct
spec:
  allowCrossNamespaceImport: true
  instanceSelector:
    matchLabels:
      grafana: "home"
  folder: Databases
  resyncPeriod: 10m
  configMapRef:
    name: grafana-dashboards
    key: pgbouncer_direct.json
  datasources:
    - inputName: "DS_PROMETHEUS"
      datasourceName: "prometheus"
---
# pod details
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaDashboard
metadata:
  name: pod-details
spec:
  allowCrossNamespaceImport: true
  instanceSelector:
    matchLabels:
      grafana: "home"
  folder: Databases
  resyncPeriod: 10m
  configMapRef:
    name: grafana-dashboards
    key: pod_details.json
  datasources:
    - inputName: "DS_PROMETHEUS"
      datasourceName: "prometheus"
---
# # PostgreSQL Details Dashboard
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaDashboard
metadata:
  name: postgresql-details
spec:
  allowCrossNamespaceImport: true
  instanceSelector:
    matchLabels:
      grafana: "home"
  folder: Databases
  resyncPeriod: 10m
  configMapRef:
    name: grafana-dashboards
    key: postgresql_details.json
  datasources:
    - inputName: "DS_PROMETHEUS"
      datasourceName: "prometheus"
#
---
# PostgreSQL Overview Dashboard
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaDashboard
metadata:
  name: postgresql-overview
spec:
  allowCrossNamespaceImport: true
  instanceSelector:
    matchLabels:
      grafana: "home"
  folder: Databases
  resyncPeriod: 10m
  configMapRef:
    name: grafana-dashboards
    key: postgresql_overview.json
  datasources:
    - inputName: "DS_PROMETHEUS"
      datasourceName: "prometheus"

---
# PostgreSQL Service Health Dashboard
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaDashboard
metadata:
  name: postgresql-service-health
spec:
  allowCrossNamespaceImport: true
  instanceSelector:
    matchLabels:
      grafana: "home"
  folder: Databases
  resyncPeriod: 10m
  configMapRef:
    name: grafana-dashboards
    key: postgresql_service_health.json
  datasources:
    - inputName: "DS_PROMETHEUS"
      datasourceName: "prometheus"
#
---
# # Query Statistics Dashboard
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaDashboard
metadata:
  name: query-statistics
spec:
  allowCrossNamespaceImport: true
  instanceSelector:
    matchLabels:
      grafana: "home"
  folder: Databases
  resyncPeriod: 10m
  configMapRef:
    name: grafana-dashboards
    key: query_statistics.json
  datasources:
    - inputName: "DS_PROMETHEUS"
      datasourceName: "prometheus"
---
```
```
# INFO: https://github.com/CrunchyData/postgres-operator/issues/2199#issuecomment-2412062711
---
apiVersion: monitoring.coreos.com/v1
kind: PodMonitor
metadata:
  name: crunchy-postgres-exporter
spec:
  jobLabel: crunchy-postgres-exporter
  selector:
    matchLabels:
      postgres-operator.crunchydata.com/crunchy-postgres-exporter: "true"
  podMetricsEndpoints:
    - interval: 15s
      port: exporter
      scrapeTimeout: 10s
      relabelings:
        # Keep exporter port and drop all others
        # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#pod
        - sourceLabels: [__meta_kubernetes_pod_container_port_number]
          action: keep
          regex: "9187"
        # Set label for namespace
        - sourceLabels: [__meta_kubernetes_namespace]
          targetLabel: kubernetes_namespace
        # Set label for pod name
        - sourceLabels: [__meta_kubernetes_pod_name]
          targetLabel: pod
        # Convert namespace and cluster name to pg_cluster=namespace:cluster
        - sourceLabels:
            [
              __meta_kubernetes_namespace,
              __meta_kubernetes_pod_label_postgres_operator_crunchydata_com_cluster,
            ]
          targetLabel: pg_cluster
          separator: ":"
          replacement: "$1$2"
        # Convert kubernetes pod ip to ip
        - sourceLabels: [__meta_kubernetes_pod_ip]
          targetLabel: ip
        # Convert postgres-operator.crunchydata.com/instance to deployment
        - sourceLabels:
            [
              __meta_kubernetes_pod_label_postgres_operator_crunchydata_com_instance,
            ]
          targetLabel: deployment
        # Convert postgres-operator.crunchydata.com/role to role
        - sourceLabels:
            [__meta_kubernetes_pod_label_postgres_operator_crunchydata_com_role]
          targetLabel: role
        # Missing Cluster name for dashbaord
        - sourceLabels:
            [
              __meta_kubernetes_pod_label_postgres_operator_crunchydata_com_cluster,
            ]
          targetLabel: cluster_name
---
```


</details>

- Installation method:  
    - [ ] Binary install from source, version:  
    - [x] OS package repository, distro, and version:  kubernetes + Operator
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [x] Other:  
- [x] PostgreSQL, Specify version(s):  17
- [ ] docs tested with hugo version(s):  

### Code testing

Have you tested your changes against:
- [ ] RedHat/CentOS
- [ ] Ubuntu
- [x] Not applicable

If your code touches sql_exporter, have you:
- [ ] Tested against all versions of PostgreSQL affected
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches node_exporter, have you:
- [ ] Ensure that exporter runs with no scrape errors
- [x] Not applicable

If your code touches Prometheus, have you:
- [ ] Ensured all configuration changes pass `promtool check config`
- [ ] Ensured all alert rule changes pass `promtool check rules`
- [ ] Prometheus runs without issue
- [ ] Alertmanager runs without issue
- [] Not applicable

If your code touches Grafana, have you:
- [ ] Ensured Grafana runs without issue
- [x] Ensured relevant dashboards load without issue
- [ ] Not applicable

### Checklist:
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [ ] the release notes  
    - [ ] the upgrade doc  
