### PR TITLE
Fix backup status query

### DIFF
--- a/changelogs/fragments/481.yml
+++ b/changelogs/fragments/481.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - grafana - Fixed container postgresql details dashboard query for last completed backup

--- a/grafana/containers/postgresql_details.json
+++ b/grafana/containers/postgresql_details.json
@@ -151,7 +151,7 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "expr": "min(ccp_backrest_last_incr_backup_time_since_completion_seconds{pg_cluster=\"[[cluster]]\"}, ccp_backrest_last_diff_backup_time_since_completion_seconds{pg_cluster=\"[[cluster]]\"}, ccp_backrest_last_full_backup_time_since_completion_seconds{pg_cluster=\"[[cluster]]\"})",
+          "expr": "min(ccp_backrest_last_incr_backup_time_since_completion_seconds{pg_cluster=\"[[cluster]]\"} or ccp_backrest_last_diff_backup_time_since_completion_seconds{pg_cluster=\"[[cluster]]\"} or ccp_backrest_last_full_backup_time_since_completion_seconds{pg_cluster=\"[[cluster]]\"}) ",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,


### PR DESCRIPTION
# Description  

The backup status query was incorrectly changed before. This change uses the original query as a model, but simplifies the query based on the underlying metrics. This query was tested against both postgres_exporter and OTEL solutions in PGO.

Please indicate what kind of change your PR includes (multiple selections are acceptable):

- [x] Bugfix
- [ ] Enhancement
- [ ] Breaking Change
- [ ] Documentation

## Testing
- Installation method:  
    - [ ] Binary install from source, version:  
    - [ ] OS package repository, distro, and version:  
    - [ ] Local package server, version:  
    - [ ] Custom-built package, version:  
    - [x] Other:  PGO monitoring stack
- [x] PostgreSQL, Specify version(s):  17
- [ ] docs tested with hugo version(s):  

### Code testing

Have you tested your changes against:
- [ ] RedHat/CentOS
- [ ] Ubuntu
- [x] Not applicable

If your code touches Grafana, have you:
- [x ] Ensured Grafana runs without issue
- [x] Ensured relevant dashboards load without issue
- [ ] Not applicable

### Checklist:
- I have made corresponding changes to:  
    - [ ] the documentation  
    - [x] the release notes  
    - [ ] the upgrade doc  
